### PR TITLE
feat: Configuration System (PR 2/8)

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -18,9 +20,23 @@ Examples:
   gh cost-center config
   gh cost-center config --config path/to/config.yaml`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// TODO: Wire to business logic in later PRs
-		fmt.Println("config command called")
+		summary := cfgManager.Summary()
+
+		// Print in sorted key order for deterministic output.
+		keys := make([]string, 0, len(summary))
+		for k := range summary {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		fmt.Println("Current configuration:")
+		fmt.Println(strings.Repeat("-", 50))
+		for _, k := range keys {
+			fmt.Printf("  %-35s %v\n", k+":", summary[k])
+		}
+		fmt.Println(strings.Repeat("-", 50))
 		fmt.Printf("  config file: %s\n", cfgFile)
+
 		return nil
 	},
 }

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/renan-alm/gh-cost-center
 
 go 1.25
 
-require github.com/spf13/cobra v1.10.2
+require (
+	github.com/spf13/cobra v1.10.2
+	gopkg.in/yaml.v3 v3.0.1
+)
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,4 +7,7 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,436 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Default values mirroring the Python implementation.
+const (
+	DefaultCostCenterMode    = "users"
+	DefaultTeamsScope        = "enterprise"
+	DefaultTeamsMode         = "auto"
+	DefaultLogLevel          = "INFO"
+	DefaultExportDir         = "exports"
+	DefaultNoPRUsCCID        = "CC-001-NO-PRUS"
+	DefaultPRUsAllowedCCID   = "CC-002-PRUS-ALLOWED"
+	DefaultNoPRUsCCName      = "00 - No PRU overages"
+	DefaultPRUsAllowedCCName = "01 - PRU overages allowed"
+	DefaultAPIBaseURL        = "https://api.github.com"
+
+	timestampFileName = ".last_run_timestamp"
+)
+
+// Placeholder values that indicate the config has not been customised.
+var placeholderEnterpriseValues = map[string]bool{
+	"":                             true,
+	"REPLACE_WITH_ENTERPRISE_SLUG": true,
+	"your_enterprise_name":         true,
+}
+
+var placeholderCCValues = map[string][]string{
+	"NoPRUsCostCenterID":      {"REPLACE_WITH_NO_PRUS_COST_CENTER_ID", DefaultNoPRUsCCID},
+	"PRUsAllowedCostCenterID": {"REPLACE_WITH_PRUS_ALLOWED_COST_CENTER_ID", DefaultPRUsAllowedCCID},
+}
+
+// Manager loads, validates, and exposes configuration.
+type Manager struct {
+	cfg  Config
+	path string
+	log  *slog.Logger
+
+	// Resolved values after applying fallback chains and env overrides.
+	Enterprise                      string
+	APIBaseURL                      string
+	CostCenterMode                  string
+	NoPRUsCostCenterID              string
+	PRUsAllowedCostCenterID         string
+	PRUsExceptionUsers              []string
+	AutoCreate                      bool
+	NoPRUsCostCenterName            string
+	PRUsAllowedCostCenterName       string
+	EnableIncremental               bool
+	TeamsEnabled                    bool
+	TeamsScope                      string
+	TeamsMode                       string
+	TeamsOrganizations              []string
+	TeamsAutoCreate                 bool
+	TeamsMappings                   map[string]string
+	TeamsRemoveUsersNoLongerInTeams bool
+	BudgetsEnabled                  bool
+	BudgetProducts                  map[string]ProductBudget
+	ExportDir                       string
+	LogLevel                        string
+	LogFile                         string
+	RepositoryConfig                *RepositoryConfig
+
+	timestampFile string
+}
+
+// Load reads the YAML config at path, applies env-var overrides, backward-
+// compatible fallback chains, and validates required fields.
+func Load(path string, logger *slog.Logger) (*Manager, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	m := &Manager{
+		path: path,
+		log:  logger,
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			logger.Warn("Config file not found, using defaults", "path", path)
+			// Continue with zero-value Config; defaults are applied below.
+		} else {
+			return nil, fmt.Errorf("reading config file: %w", err)
+		}
+	} else {
+		if err := yaml.Unmarshal(data, &m.cfg); err != nil {
+			return nil, fmt.Errorf("parsing config YAML: %w", err)
+		}
+	}
+
+	if err := m.resolve(); err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}
+
+// Raw returns the underlying parsed Config struct.
+func (m *Manager) Raw() *Config {
+	return &m.cfg
+}
+
+// resolve applies env-var overrides, fallbacks, defaults, and validation.
+func (m *Manager) resolve() error {
+	// --- Enterprise ---
+	m.Enterprise = envOrFallback("GITHUB_ENTERPRISE", m.cfg.GitHub.Enterprise)
+	if placeholderEnterpriseValues[m.Enterprise] {
+		// Re-check env explicitly in case YAML had a placeholder.
+		if v := os.Getenv("GITHUB_ENTERPRISE"); v != "" && !placeholderEnterpriseValues[v] {
+			m.Enterprise = v
+		} else {
+			return fmt.Errorf("github enterprise must be configured (set env GITHUB_ENTERPRISE or update config github.enterprise)")
+		}
+	}
+
+	// --- API base URL ---
+	rawURL := envOrFallback("GITHUB_API_BASE_URL", m.cfg.GitHub.APIBaseURL)
+	if rawURL == "" {
+		rawURL = DefaultAPIBaseURL
+	}
+	apiURL, err := validateAPIURL(rawURL, m.log)
+	if err != nil {
+		return err
+	}
+	m.APIBaseURL = apiURL
+
+	// --- Cost center mode ---
+	m.CostCenterMode = defaultString(m.cfg.GitHub.CostCenters.Mode, DefaultCostCenterMode)
+
+	// --- Repository config (only when mode is "repository") ---
+	if m.CostCenterMode == "repository" {
+		rc := m.cfg.GitHub.CostCenters.RepositoryConfig
+		if err := validateRepositoryConfig(&rc); err != nil {
+			return err
+		}
+		m.RepositoryConfig = &rc
+		m.log.Info("Repository mode enabled", "mappings", len(rc.ExplicitMappings))
+	}
+
+	// --- Cost centers (PRU-tier) with backward-compatible fallback chains ---
+	cc := m.cfg.CostCenters
+
+	m.NoPRUsCostCenterID = firstNonEmpty(cc.NoPRUsCostCenterID, cc.NoPRUsCostCenterOld, DefaultNoPRUsCCID)
+	m.PRUsAllowedCostCenterID = firstNonEmpty(cc.PRUsAllowedCostCenterID, cc.PRUsAllowedCostCenterOld, DefaultPRUsAllowedCCID)
+	m.NoPRUsCostCenterName = firstNonEmpty(cc.NoPRUsCostCenterName, cc.NoPRUNameOld, DefaultNoPRUsCCName)
+	m.PRUsAllowedCostCenterName = firstNonEmpty(cc.PRUsAllowedCostCenterName, cc.PRUAllowedNameOld, DefaultPRUsAllowedCCName)
+
+	m.PRUsExceptionUsers = cc.PRUsExceptionUsers
+	if m.PRUsExceptionUsers == nil {
+		m.PRUsExceptionUsers = []string{}
+	}
+
+	m.AutoCreate = cc.AutoCreate
+	m.EnableIncremental = cc.EnableIncremental
+
+	// --- Teams ---
+	t := m.cfg.Teams
+	m.TeamsEnabled = t.Enabled
+	m.TeamsScope = defaultString(t.Scope, DefaultTeamsScope)
+	m.TeamsMode = defaultString(t.Mode, DefaultTeamsMode)
+	m.TeamsOrganizations = t.Organizations
+	if m.TeamsOrganizations == nil {
+		m.TeamsOrganizations = []string{}
+	}
+	m.TeamsAutoCreate = t.AutoCreate
+	m.TeamsMappings = t.TeamMappings
+	if m.TeamsMappings == nil {
+		m.TeamsMappings = map[string]string{}
+	}
+	// Backward-compatible fallback: remove_users_no_longer_in_teams → remove_orphaned_users
+	m.TeamsRemoveUsersNoLongerInTeams = boolPtrDefault(t.RemoveUsersNoLongerInTeams, boolPtrDefault(t.RemoveOrphanedUsersOld, true))
+
+	// --- Budgets ---
+	b := m.cfg.Budgets
+	m.BudgetsEnabled = b.Enabled
+	m.BudgetProducts = b.Products
+	if m.BudgetProducts == nil {
+		m.BudgetProducts = map[string]ProductBudget{
+			"copilot": {Amount: 100, Enabled: true},
+			"actions": {Amount: 125, Enabled: true},
+		}
+	}
+
+	// --- Logging ---
+	m.LogLevel = defaultString(m.cfg.Logging.Level, DefaultLogLevel)
+	m.LogFile = m.cfg.Logging.File
+
+	// --- Export ---
+	m.ExportDir = defaultString(m.cfg.ExportDir, DefaultExportDir)
+	m.timestampFile = filepath.Join(m.ExportDir, timestampFileName)
+
+	return nil
+}
+
+// EnableAutoCreation turns on auto-creation mode at runtime (--create-cost-centers).
+func (m *Manager) EnableAutoCreation() {
+	m.AutoCreate = true
+}
+
+// CheckConfigWarnings logs warnings for placeholder values still present.
+func (m *Manager) CheckConfigWarnings() {
+	if m.AutoCreate {
+		return
+	}
+	for field, placeholders := range placeholderCCValues {
+		var val string
+		switch field {
+		case "NoPRUsCostCenterID":
+			val = m.NoPRUsCostCenterID
+		case "PRUsAllowedCostCenterID":
+			val = m.PRUsAllowedCostCenterID
+		}
+		for _, p := range placeholders {
+			if val == p {
+				m.log.Warn("Configuration appears to be a placeholder — update config/config.yaml with real cost center IDs before applying",
+					"field", field, "value", val)
+				break
+			}
+		}
+	}
+
+	if len(m.PRUsExceptionUsers) == 0 {
+		m.log.Info("No PRUs exception users configured — all users will be assigned to the default no_prus cost center")
+	}
+}
+
+// timestampData represents the JSON stored in the last-run timestamp file.
+type timestampData struct {
+	LastRun string `json:"last_run"`
+	SavedAt string `json:"saved_at"`
+}
+
+// SaveLastRunTimestamp persists the given timestamp (or now) to the export dir.
+func (m *Manager) SaveLastRunTimestamp(t *time.Time) error {
+	now := time.Now().UTC()
+	if t == nil {
+		t = &now
+	}
+
+	dir := filepath.Dir(m.timestampFile)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("creating export directory: %w", err)
+	}
+
+	td := timestampData{
+		LastRun: t.UTC().Format(time.RFC3339),
+		SavedAt: now.Format(time.RFC3339),
+	}
+
+	data, err := json.MarshalIndent(td, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshalling timestamp: %w", err)
+	}
+
+	if err := os.WriteFile(m.timestampFile, data, 0o644); err != nil {
+		return fmt.Errorf("writing timestamp file: %w", err)
+	}
+
+	m.log.Info("Saved last run timestamp", "timestamp", td.LastRun)
+	return nil
+}
+
+// LoadLastRunTimestamp reads the last-run timestamp from the export dir.
+// Returns nil if no previous timestamp exists.
+func (m *Manager) LoadLastRunTimestamp() (*time.Time, error) {
+	data, err := os.ReadFile(m.timestampFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			m.log.Info("No previous run timestamp found — will process all users")
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading timestamp file: %w", err)
+	}
+
+	var td timestampData
+	if err := json.Unmarshal(data, &td); err != nil {
+		return nil, fmt.Errorf("parsing timestamp file: %w", err)
+	}
+
+	if td.LastRun == "" {
+		m.log.Warn("Invalid timestamp file format")
+		return nil, nil
+	}
+
+	t, err := time.Parse(time.RFC3339, td.LastRun)
+	if err != nil {
+		return nil, fmt.Errorf("parsing timestamp value: %w", err)
+	}
+
+	m.log.Info("Loaded last run timestamp", "timestamp", td.LastRun)
+	return &t, nil
+}
+
+// Summary returns a human-readable map of current configuration for display.
+func (m *Manager) Summary() map[string]any {
+	s := map[string]any{
+		"enterprise":                  m.Enterprise,
+		"api_base_url":                m.APIBaseURL,
+		"cost_center_mode":            m.CostCenterMode,
+		"no_prus_cost_center_id":      m.NoPRUsCostCenterID,
+		"prus_allowed_cost_center_id": m.PRUsAllowedCostCenterID,
+		"prus_exception_users_count":  len(m.PRUsExceptionUsers),
+		"auto_create":                 m.AutoCreate,
+		"enable_incremental":          m.EnableIncremental,
+		"teams_enabled":               m.TeamsEnabled,
+		"teams_scope":                 m.TeamsScope,
+		"teams_mode":                  m.TeamsMode,
+		"budgets_enabled":             m.BudgetsEnabled,
+		"log_level":                   m.LogLevel,
+		"export_dir":                  m.ExportDir,
+	}
+
+	if m.Enterprise != "" {
+		s["no_prus_cost_center_url"] = fmt.Sprintf(
+			"https://github.com/enterprises/%s/billing/cost_centers/%s",
+			m.Enterprise, m.NoPRUsCostCenterID,
+		)
+		s["prus_allowed_cost_center_url"] = fmt.Sprintf(
+			"https://github.com/enterprises/%s/billing/cost_centers/%s",
+			m.Enterprise, m.PRUsAllowedCostCenterID,
+		)
+	}
+
+	return s
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// validateAPIURL validates and normalises a GitHub API base URL.
+func validateAPIURL(raw string, log *slog.Logger) (string, error) {
+	if raw == "" {
+		return "", fmt.Errorf("GitHub API base URL must be a non-empty string")
+	}
+
+	raw = strings.TrimRight(raw, "/")
+
+	if !strings.HasPrefix(raw, "https://") {
+		return "", fmt.Errorf("GitHub API base URL must use HTTPS: %s", raw)
+	}
+
+	switch {
+	case raw == DefaultAPIBaseURL:
+		log.Info("Using standard GitHub API", "url", raw)
+
+	case strings.Contains(raw, ".ghe.com"):
+		u, err := url.Parse(raw)
+		if err != nil {
+			return "", fmt.Errorf("invalid API URL: %w", err)
+		}
+		host := u.Hostname()
+		if !strings.HasPrefix(host, "api.") || !strings.HasSuffix(host, ".ghe.com") {
+			return "", fmt.Errorf(
+				"GitHub Enterprise Data Resident API URL should match 'https://api.{subdomain}.ghe.com', got: %s", raw)
+		}
+		subdomain := host[4 : len(host)-8] // strip "api." and ".ghe.com"
+		if subdomain == "" {
+			return "", fmt.Errorf("invalid GHE Data Resident URL — missing subdomain: %s", raw)
+		}
+		log.Info("Using GitHub Enterprise Data Resident API", "subdomain", subdomain, "url", raw)
+
+	case strings.Contains(raw, "/api/v3"):
+		log.Info("Using GitHub Enterprise Server API", "url", raw)
+
+	default:
+		log.Warn("Using custom GitHub API URL (non-standard pattern)",
+			"url", raw,
+			"expected", "https://api.github.com | https://api.{subdomain}.ghe.com | https://{hostname}/api/v3")
+	}
+
+	return raw, nil
+}
+
+// validateRepositoryConfig checks that each explicit mapping has the required fields.
+func validateRepositoryConfig(rc *RepositoryConfig) error {
+	for i, em := range rc.ExplicitMappings {
+		if em.CostCenter == "" {
+			return fmt.Errorf("explicit_mapping[%d]: missing 'cost_center'", i)
+		}
+		if em.PropertyName == "" {
+			return fmt.Errorf("explicit_mapping[%d]: missing 'property_name'", i)
+		}
+		if len(em.PropertyValues) == 0 {
+			return fmt.Errorf("explicit_mapping[%d]: missing 'property_values'", i)
+		}
+	}
+	return nil
+}
+
+// envOrFallback returns the env var value if set, otherwise the YAML fallback.
+func envOrFallback(envKey, yamlValue string) string {
+	if v := os.Getenv(envKey); v != "" {
+		return v
+	}
+	return yamlValue
+}
+
+// firstNonEmpty returns the first non-empty string from the arguments.
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// defaultString returns val if non-empty, otherwise def.
+func defaultString(val, def string) string {
+	if val != "" {
+		return val
+	}
+	return def
+}
+
+// boolPtrDefault dereferences a *bool, returning def if the pointer is nil.
+func boolPtrDefault(p *bool, def bool) bool {
+	if p != nil {
+		return *p
+	}
+	return def
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,537 @@
+package config
+
+import (
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// helper to write a temp YAML config and return its path.
+func writeConfig(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatalf("writing temp config: %v", err)
+	}
+	return p
+}
+
+func logger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+}
+
+// ---------- Loading the example config ----------
+
+func TestLoad_ExampleConfig(t *testing.T) {
+	// Use the repo's config.example.yaml — it must parse without error
+	// when the enterprise env var is provided.
+	t.Setenv("GITHUB_ENTERPRISE", "test-enterprise")
+	// Locate config.example.yaml relative to this test file (internal/config/ → ../../config/).
+	examplePath := filepath.Join("..", "..", "config", "config.example.yaml")
+	m, err := Load(examplePath, logger())
+	if err != nil {
+		t.Fatalf("Load config.example.yaml: %v", err)
+	}
+	if m.Enterprise != "test-enterprise" {
+		t.Errorf("enterprise = %q, want %q", m.Enterprise, "test-enterprise")
+	}
+	if m.CostCenterMode != "users" {
+		t.Errorf("cost_center_mode = %q, want %q", m.CostCenterMode, "users")
+	}
+}
+
+// ---------- Minimal valid config ----------
+
+func TestLoad_MinimalConfig(t *testing.T) {
+	yaml := `
+github:
+  enterprise: "my-ent"
+`
+	m, err := Load(writeConfig(t, yaml), logger())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if m.Enterprise != "my-ent" {
+		t.Errorf("enterprise = %q", m.Enterprise)
+	}
+	if m.APIBaseURL != DefaultAPIBaseURL {
+		t.Errorf("api_base_url = %q, want default", m.APIBaseURL)
+	}
+	if m.CostCenterMode != DefaultCostCenterMode {
+		t.Errorf("mode = %q, want %q", m.CostCenterMode, DefaultCostCenterMode)
+	}
+}
+
+// ---------- Missing enterprise ----------
+
+func TestLoad_MissingEnterprise(t *testing.T) {
+	yaml := `
+github:
+  enterprise: ""
+`
+	t.Setenv("GITHUB_ENTERPRISE", "")
+	_, err := Load(writeConfig(t, yaml), logger())
+	if err == nil {
+		t.Fatal("expected error for missing enterprise")
+	}
+}
+
+// ---------- Enterprise placeholder in YAML, real value in env ----------
+
+func TestLoad_EnterprisePlaceholderWithEnvOverride(t *testing.T) {
+	yaml := `
+github:
+  enterprise: "your_enterprise_name"
+`
+	t.Setenv("GITHUB_ENTERPRISE", "real-ent")
+	m, err := Load(writeConfig(t, yaml), logger())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if m.Enterprise != "real-ent" {
+		t.Errorf("enterprise = %q, want %q", m.Enterprise, "real-ent")
+	}
+}
+
+// ---------- Env var overrides ----------
+
+func TestLoad_EnvVarOverrides(t *testing.T) {
+	yaml := `
+github:
+  enterprise: "yaml-ent"
+  api_base_url: "https://api.github.com"
+`
+	t.Setenv("GITHUB_ENTERPRISE", "env-ent")
+	t.Setenv("GITHUB_API_BASE_URL", "https://api.corp.ghe.com")
+	m, err := Load(writeConfig(t, yaml), logger())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if m.Enterprise != "env-ent" {
+		t.Errorf("enterprise = %q, want env-ent", m.Enterprise)
+	}
+	if m.APIBaseURL != "https://api.corp.ghe.com" {
+		t.Errorf("api_base_url = %q, want env value", m.APIBaseURL)
+	}
+}
+
+// ---------- Backward-compatible fallback chains ----------
+
+func TestLoad_FallbackChains(t *testing.T) {
+	yaml := `
+github:
+  enterprise: "ent"
+cost_centers:
+  no_prus_cost_center: "OLD-CC-001"
+  prus_allowed_cost_center: "OLD-CC-002"
+  no_pru_name: "Old No PRU"
+  pru_allowed_name: "Old PRU Allowed"
+`
+	m, err := Load(writeConfig(t, yaml), logger())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if m.NoPRUsCostCenterID != "OLD-CC-001" {
+		t.Errorf("NoPRUsCostCenterID = %q, want OLD-CC-001", m.NoPRUsCostCenterID)
+	}
+	if m.PRUsAllowedCostCenterID != "OLD-CC-002" {
+		t.Errorf("PRUsAllowedCostCenterID = %q, want OLD-CC-002", m.PRUsAllowedCostCenterID)
+	}
+	if m.NoPRUsCostCenterName != "Old No PRU" {
+		t.Errorf("NoPRUsCostCenterName = %q", m.NoPRUsCostCenterName)
+	}
+	if m.PRUsAllowedCostCenterName != "Old PRU Allowed" {
+		t.Errorf("PRUsAllowedCostCenterName = %q", m.PRUsAllowedCostCenterName)
+	}
+}
+
+func TestLoad_NewKeysOverrideOldKeys(t *testing.T) {
+	yaml := `
+github:
+  enterprise: "ent"
+cost_centers:
+  no_prus_cost_center_id: "NEW-CC-001"
+  no_prus_cost_center: "OLD-CC-001"
+  prus_allowed_cost_center_id: "NEW-CC-002"
+  prus_allowed_cost_center: "OLD-CC-002"
+`
+	m, err := Load(writeConfig(t, yaml), logger())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if m.NoPRUsCostCenterID != "NEW-CC-001" {
+		t.Errorf("NoPRUsCostCenterID = %q, want NEW-CC-001", m.NoPRUsCostCenterID)
+	}
+	if m.PRUsAllowedCostCenterID != "NEW-CC-002" {
+		t.Errorf("PRUsAllowedCostCenterID = %q, want NEW-CC-002", m.PRUsAllowedCostCenterID)
+	}
+}
+
+// ---------- Teams backward-compatible key ----------
+
+func TestLoad_TeamsRemoveOrphanedFallback(t *testing.T) {
+	yaml := `
+github:
+  enterprise: "ent"
+teams:
+  enabled: true
+  remove_orphaned_users: false
+`
+	m, err := Load(writeConfig(t, yaml), logger())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if m.TeamsRemoveUsersNoLongerInTeams != false {
+		t.Error("expected TeamsRemoveUsersNoLongerInTeams = false (via old key)")
+	}
+}
+
+func TestLoad_TeamsNewKeyOverridesOld(t *testing.T) {
+	yaml := `
+github:
+  enterprise: "ent"
+teams:
+  enabled: true
+  remove_users_no_longer_in_teams: true
+  remove_orphaned_users: false
+`
+	m, err := Load(writeConfig(t, yaml), logger())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if m.TeamsRemoveUsersNoLongerInTeams != true {
+		t.Error("expected new key to take precedence")
+	}
+}
+
+// ---------- API URL validation ----------
+
+func TestValidateAPIURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+		want    string
+	}{
+		{"standard github", "https://api.github.com", false, "https://api.github.com"},
+		{"standard with trailing slash", "https://api.github.com/", false, "https://api.github.com"},
+		{"ghe data resident", "https://api.corp.ghe.com", false, "https://api.corp.ghe.com"},
+		{"ghe server", "https://github.myco.com/api/v3", false, "https://github.myco.com/api/v3"},
+		{"http rejected", "http://api.github.com", true, ""},
+		{"empty string", "", true, ""},
+		{"bad ghe pattern", "https://corp.ghe.com", true, ""},
+		{"custom non-standard", "https://custom.example.com", false, "https://custom.example.com"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validateAPIURL(tt.url, logger())
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------- Repository config validation ----------
+
+func TestValidateRepositoryConfig(t *testing.T) {
+	valid := &RepositoryConfig{
+		ExplicitMappings: []ExplicitMapping{
+			{CostCenter: "CC1", PropertyName: "team", PropertyValues: []string{"a"}},
+		},
+	}
+	if err := validateRepositoryConfig(valid); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	missing := &RepositoryConfig{
+		ExplicitMappings: []ExplicitMapping{
+			{CostCenter: "", PropertyName: "team", PropertyValues: []string{"a"}},
+		},
+	}
+	if err := validateRepositoryConfig(missing); err == nil {
+		t.Fatal("expected error for missing cost_center")
+	}
+
+	noValues := &RepositoryConfig{
+		ExplicitMappings: []ExplicitMapping{
+			{CostCenter: "CC1", PropertyName: "team", PropertyValues: []string{}},
+		},
+	}
+	if err := validateRepositoryConfig(noValues); err == nil {
+		t.Fatal("expected error for empty property_values")
+	}
+}
+
+// ---------- Repository mode ----------
+
+func TestLoad_RepositoryMode(t *testing.T) {
+	yaml := `
+github:
+  enterprise: "ent"
+  cost_centers:
+    mode: "repository"
+    repository_config:
+      explicit_mappings:
+        - cost_center: "Platform"
+          property_name: "team"
+          property_values:
+            - "platform"
+            - "infra"
+`
+	m, err := Load(writeConfig(t, yaml), logger())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if m.CostCenterMode != "repository" {
+		t.Errorf("mode = %q", m.CostCenterMode)
+	}
+	if m.RepositoryConfig == nil {
+		t.Fatal("RepositoryConfig is nil")
+	}
+	if len(m.RepositoryConfig.ExplicitMappings) != 1 {
+		t.Fatalf("expected 1 mapping, got %d", len(m.RepositoryConfig.ExplicitMappings))
+	}
+	if m.RepositoryConfig.ExplicitMappings[0].CostCenter != "Platform" {
+		t.Error("wrong cost center")
+	}
+}
+
+// ---------- Timestamp save/load round trip ----------
+
+func TestTimestamp_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `
+github:
+  enterprise: "ent"
+export_dir: "` + dir + `"
+`
+	m, err := Load(writeConfig(t, yaml), logger())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	ts := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
+	if err := m.SaveLastRunTimestamp(&ts); err != nil {
+		t.Fatalf("SaveLastRunTimestamp: %v", err)
+	}
+	got, err := m.LoadLastRunTimestamp()
+	if err != nil {
+		t.Fatalf("LoadLastRunTimestamp: %v", err)
+	}
+	if got == nil {
+		t.Fatal("got nil timestamp")
+	}
+	if !got.Equal(ts) {
+		t.Errorf("timestamp = %v, want %v", got, ts)
+	}
+}
+
+func TestTimestamp_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `
+github:
+  enterprise: "ent"
+export_dir: "` + dir + `"
+`
+	m, err := Load(writeConfig(t, yaml), logger())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got, err := m.LoadLastRunTimestamp()
+	if err != nil {
+		t.Fatalf("LoadLastRunTimestamp: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}
+
+// ---------- Placeholder warnings ----------
+
+func TestCheckConfigWarnings_NoAutoCreate(t *testing.T) {
+	yaml := `
+github:
+  enterprise: "ent"
+cost_centers:
+  no_prus_cost_center_id: "REPLACE_WITH_NO_PRUS_COST_CENTER_ID"
+`
+	m, err := Load(writeConfig(t, yaml), logger())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// Should not panic; warnings go to log.
+	m.CheckConfigWarnings()
+}
+
+func TestCheckConfigWarnings_AutoCreateSkips(t *testing.T) {
+	yaml := `
+github:
+  enterprise: "ent"
+cost_centers:
+  auto_create: true
+  no_prus_cost_center_id: "REPLACE_WITH_NO_PRUS_COST_CENTER_ID"
+`
+	m, err := Load(writeConfig(t, yaml), logger())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// With auto_create=true, placeholders should be silently accepted.
+	m.CheckConfigWarnings()
+}
+
+// ---------- Summary ----------
+
+func TestSummary_ContainsExpectedKeys(t *testing.T) {
+	yaml := `
+github:
+  enterprise: "ent"
+`
+	m, err := Load(writeConfig(t, yaml), logger())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	s := m.Summary()
+	expectedKeys := []string{
+		"enterprise",
+		"api_base_url",
+		"cost_center_mode",
+		"no_prus_cost_center_id",
+		"prus_allowed_cost_center_id",
+		"auto_create",
+		"teams_enabled",
+		"budgets_enabled",
+		"log_level",
+		"export_dir",
+		"prus_exception_users_count",
+	}
+	for _, k := range expectedKeys {
+		if _, ok := s[k]; !ok {
+			t.Errorf("Summary missing key %q", k)
+		}
+	}
+}
+
+// ---------- Config file not found defaults ----------
+
+func TestLoad_FileNotFound(t *testing.T) {
+	t.Setenv("GITHUB_ENTERPRISE", "env-ent")
+	m, err := Load("/nonexistent/config.yaml", logger())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if m.Enterprise != "env-ent" {
+		t.Errorf("enterprise = %q", m.Enterprise)
+	}
+}
+
+// ---------- EnableAutoCreation ----------
+
+func TestEnableAutoCreation(t *testing.T) {
+	yaml := `
+github:
+  enterprise: "ent"
+cost_centers:
+  auto_create: false
+`
+	m, err := Load(writeConfig(t, yaml), logger())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if m.AutoCreate {
+		t.Fatal("expected auto_create=false initially")
+	}
+	m.EnableAutoCreation()
+	if !m.AutoCreate {
+		t.Fatal("expected auto_create=true after EnableAutoCreation()")
+	}
+}
+
+// ---------- Budgets defaults ----------
+
+func TestLoad_BudgetDefaults(t *testing.T) {
+	yaml := `
+github:
+  enterprise: "ent"
+`
+	m, err := Load(writeConfig(t, yaml), logger())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(m.BudgetProducts) != 2 {
+		t.Errorf("expected 2 default budget products, got %d", len(m.BudgetProducts))
+	}
+	if m.BudgetProducts["copilot"].Amount != 100 {
+		t.Errorf("copilot amount = %d", m.BudgetProducts["copilot"].Amount)
+	}
+}
+
+// ---------- Timestamp file JSON structure ----------
+
+func TestTimestamp_JSONFormat(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `
+github:
+  enterprise: "ent"
+export_dir: "` + dir + `"
+`
+	m, err := Load(writeConfig(t, yaml), logger())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	ts := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	if err := m.SaveLastRunTimestamp(&ts); err != nil {
+		t.Fatalf("SaveLastRunTimestamp: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, timestampFileName))
+	if err != nil {
+		t.Fatalf("reading timestamp file: %v", err)
+	}
+	var td timestampData
+	if err := json.Unmarshal(data, &td); err != nil {
+		t.Fatalf("unmarshalling: %v", err)
+	}
+	if td.LastRun != "2025-01-01T00:00:00Z" {
+		t.Errorf("last_run = %q", td.LastRun)
+	}
+	if td.SavedAt == "" {
+		t.Error("saved_at is empty")
+	}
+}
+
+// ---------- Helper tests ----------
+
+func TestFirstNonEmpty(t *testing.T) {
+	if got := firstNonEmpty("", "", "c"); got != "c" {
+		t.Errorf("got %q", got)
+	}
+	if got := firstNonEmpty("a", "b"); got != "a" {
+		t.Errorf("got %q", got)
+	}
+	if got := firstNonEmpty(""); got != "" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestBoolPtrDefault(t *testing.T) {
+	tr := true
+	fa := false
+	if got := boolPtrDefault(&tr, false); got != true {
+		t.Error("expected true")
+	}
+	if got := boolPtrDefault(&fa, true); got != false {
+		t.Error("expected false")
+	}
+	if got := boolPtrDefault(nil, true); got != true {
+		t.Error("expected default true")
+	}
+}

--- a/internal/config/models.go
+++ b/internal/config/models.go
@@ -1,0 +1,92 @@
+// Package config provides typed configuration models and loading for gh-cost-center.
+package config
+
+// Config is the top-level configuration structure that mirrors the YAML file.
+type Config struct {
+	GitHub      GitHubConfig      `yaml:"github"`
+	Logging     LoggingConfig     `yaml:"logging"`
+	CostCenters CostCentersConfig `yaml:"cost_centers"`
+	Teams       TeamsConfig       `yaml:"teams"`
+	Budgets     BudgetsConfig     `yaml:"budgets"`
+	ExportDir   string            `yaml:"export_dir"`
+}
+
+// GitHubConfig holds GitHub-related settings.
+type GitHubConfig struct {
+	Enterprise  string         `yaml:"enterprise"`
+	APIBaseURL  string         `yaml:"api_base_url"`
+	CostCenters CostCenterMode `yaml:"cost_centers"`
+}
+
+// CostCenterMode selects the assignment mode and holds per-mode config.
+type CostCenterMode struct {
+	Mode             string           `yaml:"mode"` // "users", "teams", or "repository"
+	RepositoryConfig RepositoryConfig `yaml:"repository_config"`
+}
+
+// RepositoryConfig configures repository-based cost center assignment.
+type RepositoryConfig struct {
+	ExplicitMappings []ExplicitMapping `yaml:"explicit_mappings"`
+}
+
+// ExplicitMapping maps a custom-property value set to a cost center.
+type ExplicitMapping struct {
+	CostCenter     string   `yaml:"cost_center"`
+	PropertyName   string   `yaml:"property_name"`
+	PropertyValues []string `yaml:"property_values"`
+}
+
+// LoggingConfig controls log level and output file.
+type LoggingConfig struct {
+	Level string `yaml:"level"`
+	File  string `yaml:"file"`
+}
+
+// CostCentersConfig holds PRU-tier cost center settings.
+type CostCentersConfig struct {
+	// Current keys
+	NoPRUsCostCenterID      string   `yaml:"no_prus_cost_center_id"`
+	PRUsAllowedCostCenterID string   `yaml:"prus_allowed_cost_center_id"`
+	PRUsExceptionUsers      []string `yaml:"prus_exception_users"`
+
+	// Auto-creation
+	AutoCreate                bool   `yaml:"auto_create"`
+	NoPRUsCostCenterName      string `yaml:"no_prus_cost_center_name"`
+	PRUsAllowedCostCenterName string `yaml:"prus_allowed_cost_center_name"`
+
+	// Incremental processing
+	EnableIncremental bool `yaml:"enable_incremental"`
+
+	// Backward-compatible keys (old names)
+	NoPRUsCostCenterOld      string `yaml:"no_prus_cost_center"`
+	PRUsAllowedCostCenterOld string `yaml:"prus_allowed_cost_center"`
+	NoPRUNameOld             string `yaml:"no_pru_name"`
+	PRUAllowedNameOld        string `yaml:"pru_allowed_name"`
+}
+
+// TeamsConfig holds teams-integration settings.
+type TeamsConfig struct {
+	Enabled       bool              `yaml:"enabled"`
+	Scope         string            `yaml:"scope"` // "organization" or "enterprise"
+	Mode          string            `yaml:"mode"`  // "auto" or "manual"
+	Organizations []string          `yaml:"organizations"`
+	AutoCreate    bool              `yaml:"auto_create_cost_centers"`
+	TeamMappings  map[string]string `yaml:"team_mappings"`
+
+	// Current key
+	RemoveUsersNoLongerInTeams *bool `yaml:"remove_users_no_longer_in_teams"`
+	// Backward-compatible key (old name)
+	RemoveOrphanedUsersOld *bool `yaml:"remove_orphaned_users"`
+}
+
+// BudgetsConfig holds budget auto-creation settings.
+type BudgetsConfig struct {
+	Enabled  bool                     `yaml:"enabled"`
+	Products map[string]ProductBudget `yaml:"products"`
+}
+
+// ProductBudget is the budget configuration for a single product.
+type ProductBudget struct {
+	Amount  int  `yaml:"amount"`
+	Enabled bool `yaml:"enabled"`
+}


### PR DESCRIPTION
## PR 2: Configuration System

Port the full YAML config loader, env var overrides, backward-compatible keys, and validation from the Python implementation.

### What's included

- **`internal/config/models.go`** — Typed Go structs mirroring the YAML config structure: `Config`, `GitHubConfig`, `CostCentersConfig`, `TeamsConfig`, `BudgetsConfig`, `LoggingConfig`, `RepositoryConfig`, `ExplicitMapping`
- **`internal/config/config.go`** — `Manager` struct with `Load()`, backward-compatible fallback chains, env var overrides, API URL validation, placeholder detection, timestamp save/load, and config summary
- **`internal/config/config_test.go`** — Comprehensive test suite (22 tests)
- **`cmd/root.go`** — Wired config loading into `PersistentPreRunE` with structured logging (`log/slog`)
- **`cmd/config.go`** — Updated to display config summary via `Manager.Summary()`

### Key features ported

1. **Backward-compatible key fallback chains** — `no_prus_cost_center` → `no_prus_cost_center_id`, `remove_orphaned_users` → `remove_users_no_longer_in_teams`, etc.
2. **Environment variable overrides** — `GITHUB_ENTERPRISE`, `GITHUB_API_BASE_URL` (no `GITHUB_TOKEN` — auth is via `go-gh` in PR 3)
3. **API URL validation** — Standard GitHub, GHE Data Resident (`api.*.ghe.com`), and GHE Server (`*/api/v3`)
4. **Placeholder detection** — Warns if `REPLACE_WITH_*` values are still present
5. **Repository mode** — Support for repository-based cost center assignment with explicit mappings
6. **Timestamp save/load** — JSON file at `exports/.last_run_timestamp` for incremental processing
7. **Config summary** — Human-readable key-value output for `gh cost-center config`

### Config YAML structure (preserved from Python)

```yaml
github:
  enterprise: "string"
  api_base_url: "string"
  cost_centers:
    mode: "users|teams|repository"
    repository_config:
      explicit_mappings:
        - cost_center: "string"
          property_name: "string"
          property_values: ["string"]
cost_centers:
  no_prus_cost_center_id: "string"
  prus_allowed_cost_center_id: "string"
  auto_create: bool
teams:
  enabled: bool
  scope: "organization|enterprise"
budgets:
  enabled: bool
```

### Dependencies added

- `gopkg.in/yaml.v3 v3.0.1`

### Testing

- 22 tests, all passing with `-race`
- Tests cover: example config loading, minimal config, missing enterprise, env var overrides, fallback chains, teams backward-compat, API URL validation (table-driven), repository config validation, repository mode loading, timestamp round-trip, placeholder warnings, summary output, file-not-found defaults, auto-creation toggle, budget defaults, timestamp JSON format, helper functions