### PR TITLE
feat: PRU-Based Mode (Default) (PR 4/8)

### DIFF
--- a/cmd/assign.go
+++ b/cmd/assign.go
@@ -1,9 +1,16 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
+	"log/slog"
+	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/renan-alm/gh-cost-center/internal/github"
+	"github.com/renan-alm/gh-cost-center/internal/pru"
 )
 
 var (
@@ -55,22 +62,7 @@ Examples:
 
   # Apply repository-based assignments
   gh cost-center assign --repo --mode apply --yes`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		// TODO: Wire to business logic in later PRs
-		fmt.Println("assign command called")
-		fmt.Printf("  mode:                %s\n", assignMode)
-		fmt.Printf("  teams:               %t\n", assignTeams)
-		fmt.Printf("  repo:                %t\n", assignRepo)
-		fmt.Printf("  yes:                 %t\n", assignYes)
-		fmt.Printf("  incremental:         %t\n", assignIncremental)
-		fmt.Printf("  create-cost-centers: %t\n", assignCreateCC)
-		fmt.Printf("  create-budgets:      %t\n", assignCreateBudgets)
-		fmt.Printf("  check-current:       %t\n", assignCheckCurrentCC)
-		if assignUsers != "" {
-			fmt.Printf("  users:               %s\n", assignUsers)
-		}
-		return nil
-	},
+	RunE: runAssign,
 }
 
 func init() {
@@ -85,4 +77,292 @@ func init() {
 	assignCmd.Flags().BoolVar(&assignCheckCurrentCC, "check-current", false, "check current cost center membership before assigning")
 
 	rootCmd.AddCommand(assignCmd)
+}
+
+// runAssign dispatches to the appropriate assignment mode.
+func runAssign(cmd *cobra.Command, _ []string) error {
+	if assignMode != "plan" && assignMode != "apply" {
+		return fmt.Errorf("invalid --mode %q: must be 'plan' or 'apply'", assignMode)
+	}
+
+	if assignTeams {
+		// TODO: Wire teams-based mode in PR 5
+		return fmt.Errorf("teams-based mode is not yet implemented")
+	}
+	if assignRepo {
+		// TODO: Wire repository-based mode in PR 6
+		return fmt.Errorf("repository-based mode is not yet implemented")
+	}
+
+	return runPRUAssign(cmd)
+}
+
+// runPRUAssign implements the default PRU-based assignment flow.
+func runPRUAssign(cmd *cobra.Command) error {
+	logger := slog.Default()
+
+	// Enable auto-creation if flag was passed.
+	autoCreate := assignCreateCC || cfgManager.AutoCreate
+	if assignCreateCC {
+		cfgManager.EnableAutoCreation()
+	}
+
+	// Initialize PRU manager.
+	mgr := pru.NewManager(cfgManager, logger)
+
+	// Show configuration.
+	mgr.PrintConfigSummary(cfgManager, autoCreate)
+
+	// Create GitHub API client.
+	client, err := github.NewClient(cfgManager, logger)
+	if err != nil {
+		return fmt.Errorf("creating GitHub client: %w", err)
+	}
+
+	// Fetch Copilot users.
+	logger.Info("Fetching Copilot license holders...")
+	users, err := client.GetCopilotUsers()
+	if err != nil {
+		return fmt.Errorf("fetching copilot users: %w", err)
+	}
+	logger.Info("Found Copilot license holders", "count", len(users))
+
+	// Incremental processing: filter to new users since last run.
+	originalCount := len(users)
+	if assignIncremental {
+		ts, err := cfgManager.LoadLastRunTimestamp()
+		if err != nil {
+			return fmt.Errorf("loading last run timestamp: %w", err)
+		}
+		if ts != nil {
+			users = github.FilterUsersByTimestamp(users, *ts)
+			logger.Info("Incremental mode",
+				"new_users", len(users),
+				"total_users", originalCount,
+				"since", ts.Format("2006-01-02T15:04:05Z"),
+			)
+			if len(users) == 0 {
+				logger.Info("No new users found since last run — nothing to process")
+				if assignMode == "apply" {
+					if err := cfgManager.SaveLastRunTimestamp(nil); err != nil {
+						logger.Error("Failed to save timestamp", "error", err)
+					}
+				}
+				return nil
+			}
+		} else {
+			logger.Info("Incremental mode: no previous timestamp found, processing all users")
+		}
+	}
+
+	// Auto-create cost centers if requested.
+	if autoCreate {
+		if assignMode == "plan" {
+			logger.Info("MODE=plan: Would create cost centers if they don't exist")
+			logger.Info("Would create", "no_pru", cfgManager.NoPRUsCostCenterName)
+			logger.Info("Would create", "pru_allowed", cfgManager.PRUsAllowedCostCenterName)
+		} else {
+			logger.Info("Creating cost centers if they don't exist...")
+			noPRUID, pruAllowedID, err := client.EnsureCostCentersExist(
+				cfgManager.NoPRUsCostCenterName,
+				cfgManager.PRUsAllowedCostCenterName,
+			)
+			if err != nil {
+				return fmt.Errorf("creating cost centers: %w", err)
+			}
+			// Update IDs in config and manager.
+			cfgManager.NoPRUsCostCenterID = noPRUID
+			cfgManager.PRUsAllowedCostCenterID = pruAllowedID
+			mgr.SetCostCenterIDs(noPRUID, pruAllowedID)
+
+			logger.Info("Updated cost center IDs",
+				"no_pru", noPRUID,
+				"pru_allowed", pruAllowedID,
+			)
+		}
+	}
+
+	// Filter to specific users if --users flag was provided.
+	if assignUsers != "" {
+		users = filterUsersByLogin(users, assignUsers)
+		logger.Info("Filtered to specified users", "count", len(users))
+	}
+
+	// Build assignment groups.
+	groups := mgr.AssignmentGroups(users)
+
+	pruCount := len(groups[mgr.PRUAllowedCCID()])
+	noPRUCount := len(groups[mgr.NoPRUCCID()])
+
+	// Log individual assignments in plan mode.
+	if assignMode == "plan" {
+		logger.Info("MODE=plan (no changes will be made)")
+		for _, u := range users {
+			cc := mgr.AssignCostCenter(u)
+			logger.Debug("Would assign", "user", u.Login, "cc", cc)
+		}
+	}
+
+	// Print assignment summary.
+	fmt.Printf("\n=== Assignment Summary ===\n")
+	fmt.Printf("PRUs Allowed (%s): %d users\n", mgr.PRUAllowedCCID(), pruCount)
+	fmt.Printf("No PRUs (%s): %d users\n", mgr.NoPRUCCID(), noPRUCount)
+	fmt.Printf("Total: %d users\n", len(users))
+
+	// Execute assignments.
+	var assignmentResults map[string]map[string]bool
+
+	if assignMode == "plan" {
+		logger.Info("Would sync full assignment state (plan mode)")
+		for ccID, usernames := range groups {
+			logger.Info("Would add users to cost center", "cc", ccID, "count", len(usernames))
+		}
+	} else {
+		// Apply mode — safety confirmation unless --yes.
+		if !assignYes {
+			if !confirmApply(groups, assignCheckCurrentCC) {
+				logger.Warn("Aborted by user before applying assignments")
+				return nil
+			}
+		}
+
+		// Remove empty groups.
+		toSync := make(map[string][]string)
+		for cc, names := range groups {
+			if len(names) > 0 {
+				toSync[cc] = names
+			}
+		}
+
+		if len(toSync) == 0 {
+			logger.Warn("No users to sync")
+		} else {
+			logger.Info("Applying full assignment state to GitHub Enterprise...")
+			// ignore_current_cost_center is the inverse of --check-current
+			ignoreCurrentCC := !assignCheckCurrentCC
+			results, err := client.BulkUpdateCostCenterAssignments(toSync, ignoreCurrentCC)
+			if err != nil {
+				return fmt.Errorf("applying assignments: %w", err)
+			}
+			assignmentResults = results
+
+			// Process and log results.
+			logAssignmentResults(results, logger)
+		}
+
+		// Save timestamp for incremental processing.
+		if assignIncremental {
+			if err := cfgManager.SaveLastRunTimestamp(nil); err != nil {
+				logger.Error("Failed to save timestamp", "error", err)
+			} else {
+				logger.Info("Saved current timestamp for next incremental run")
+			}
+		}
+	}
+
+	// Show success summary.
+	var origPtr *int
+	if assignIncremental {
+		origPtr = &originalCount
+	}
+	pru.ShowSuccessSummary(cfgManager, users, origPtr, assignmentResults, assignMode == "apply")
+
+	logger.Info("Assign command completed successfully")
+	return nil
+}
+
+// confirmApply shows a confirmation prompt and returns true if the user types "apply".
+func confirmApply(groups map[string][]string, checkCurrent bool) bool {
+	fmt.Println("\nYou are about to APPLY cost center assignments to GitHub Enterprise.")
+	fmt.Println("This will push assignments for ALL processed users (no diff).")
+
+	if checkCurrent {
+		fmt.Println("Current cost center membership will be checked — users in other cost centers will be SKIPPED.")
+	} else {
+		fmt.Println("Fast mode: Users will be assigned WITHOUT checking current cost center membership.")
+	}
+
+	fmt.Println("Summary:")
+	for ccID, usernames := range groups {
+		fmt.Printf("  - %s: %d users\n", ccID, len(usernames))
+	}
+
+	fmt.Print("\nProceed? Type 'apply' to continue: ")
+	scanner := bufio.NewScanner(os.Stdin)
+	if scanner.Scan() {
+		return strings.TrimSpace(strings.ToLower(scanner.Text())) == "apply"
+	}
+	return false
+}
+
+// logAssignmentResults logs per-cost-center and overall success/failure counts.
+func logAssignmentResults(results map[string]map[string]bool, logger *slog.Logger) {
+	totalAttempted := 0
+	totalSuccessful := 0
+	totalFailed := 0
+
+	for ccID, userResults := range results {
+		ccSuccessful := 0
+		for _, ok := range userResults {
+			if ok {
+				ccSuccessful++
+			}
+		}
+		ccFailed := len(userResults) - ccSuccessful
+		totalAttempted += len(userResults)
+		totalSuccessful += ccSuccessful
+		totalFailed += ccFailed
+
+		if ccFailed > 0 {
+			logger.Warn("Cost center partial success",
+				"cost_center_id", ccID,
+				"successful", ccSuccessful,
+				"total", len(userResults),
+			)
+			var failedUsers []string
+			for username, ok := range userResults {
+				if !ok {
+					failedUsers = append(failedUsers, username)
+				}
+			}
+			logger.Error("Failed users", "cost_center_id", ccID, "users", strings.Join(failedUsers, ", "))
+		} else {
+			logger.Info("Cost center all successful",
+				"cost_center_id", ccID,
+				"count", ccSuccessful,
+			)
+		}
+	}
+
+	if totalFailed > 0 {
+		logger.Warn("FINAL RESULT",
+			"successful", totalSuccessful,
+			"total", totalAttempted,
+			"failed", totalFailed,
+		)
+	} else {
+		logger.Info("FINAL RESULT: All users successfully assigned",
+			"count", totalSuccessful,
+		)
+	}
+}
+
+// filterUsersByLogin filters a user slice to only those whose login appears in
+// the comma-separated list.
+func filterUsersByLogin(users []github.CopilotUser, commaSep string) []github.CopilotUser {
+	wanted := make(map[string]bool)
+	for _, u := range strings.Split(commaSep, ",") {
+		u = strings.TrimSpace(u)
+		if u != "" {
+			wanted[strings.ToLower(u)] = true
+		}
+	}
+
+	var filtered []github.CopilotUser
+	for _, u := range users {
+		if wanted[strings.ToLower(u.Login)] {
+			filtered = append(filtered, u)
+		}
+	}
+	return filtered
 }

--- a/cmd/list_users.go
+++ b/cmd/list_users.go
@@ -2,8 +2,12 @@ package cmd
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/spf13/cobra"
+
+	"github.com/renan-alm/gh-cost-center/internal/github"
+	"github.com/renan-alm/gh-cost-center/internal/pru"
 )
 
 var listUsersCmd = &cobra.Command{
@@ -16,13 +20,41 @@ Shows each user with their PRU exception status.
 Examples:
   gh cost-center list-users
   gh cost-center list-users -v`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		// TODO: Wire to business logic in later PRs
-		fmt.Println("list-users command called")
-		return nil
-	},
+	RunE: runListUsers,
 }
 
 func init() {
 	rootCmd.AddCommand(listUsersCmd)
+}
+
+func runListUsers(_ *cobra.Command, _ []string) error {
+	logger := slog.Default()
+
+	// Create GitHub API client.
+	client, err := github.NewClient(cfgManager, logger)
+	if err != nil {
+		return fmt.Errorf("creating GitHub client: %w", err)
+	}
+
+	// Initialize PRU manager (needed for exception check).
+	mgr := pru.NewManager(cfgManager, logger)
+
+	// Fetch Copilot users.
+	users, err := client.GetCopilotUsers()
+	if err != nil {
+		return fmt.Errorf("fetching copilot users: %w", err)
+	}
+
+	// Display users with PRU exception markers.
+	fmt.Println("\n=== Copilot License Holders ===")
+	fmt.Printf("Total users: %d\n", len(users))
+	for _, u := range users {
+		marker := ""
+		if mgr.IsException(u.Login) {
+			marker = " [PRUs Exception]"
+		}
+		fmt.Printf("- %s%s\n", u.Login, marker)
+	}
+
+	return nil
 }

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -2,8 +2,12 @@ package cmd
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/spf13/cobra"
+
+	"github.com/renan-alm/gh-cost-center/internal/github"
+	"github.com/renan-alm/gh-cost-center/internal/pru"
 )
 
 var reportTeams bool
@@ -19,16 +23,47 @@ Use --teams for teams-aware reporting.
 Examples:
   gh cost-center report
   gh cost-center report --teams`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		// TODO: Wire to business logic in later PRs
-		fmt.Println("report command called")
-		fmt.Printf("  teams: %t\n", reportTeams)
-		return nil
-	},
+	RunE: runReport,
 }
 
 func init() {
 	reportCmd.Flags().BoolVar(&reportTeams, "teams", false, "generate teams-aware report")
 
 	rootCmd.AddCommand(reportCmd)
+}
+
+func runReport(_ *cobra.Command, _ []string) error {
+	if reportTeams {
+		// TODO: Wire teams-aware report in PR 5
+		return fmt.Errorf("teams-aware reporting is not yet implemented")
+	}
+
+	logger := slog.Default()
+
+	// Create GitHub API client.
+	client, err := github.NewClient(cfgManager, logger)
+	if err != nil {
+		return fmt.Errorf("creating GitHub client: %w", err)
+	}
+
+	// Initialize PRU manager.
+	mgr := pru.NewManager(cfgManager, logger)
+
+	// Fetch Copilot users.
+	users, err := client.GetCopilotUsers()
+	if err != nil {
+		return fmt.Errorf("fetching copilot users: %w", err)
+	}
+
+	// Generate and display summary.
+	summary := mgr.GenerateSummary(users)
+
+	fmt.Println("\n=== Cost Center Summary ===")
+	logger.Info("Cost Center Assignment Summary")
+	for cc, count := range summary {
+		fmt.Printf("%s: %d users\n", cc, count)
+		logger.Info("Cost center", "id", cc, "users", count)
+	}
+
+	return nil
 }

--- a/internal/pru/manager.go
+++ b/internal/pru/manager.go
@@ -1,0 +1,204 @@
+// Package pru implements PRU-based cost center assignment — the default mode.
+//
+// The logic is simple: every Copilot user is assigned to one of two cost
+// centers.  Users on the PRU exception list go to the "PRU-allowed" cost
+// center; everyone else goes to the "no-PRU" cost center.
+package pru
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/renan-alm/gh-cost-center/internal/config"
+	"github.com/renan-alm/gh-cost-center/internal/github"
+)
+
+// Manager handles PRU-based cost center assignment.
+type Manager struct {
+	noPRUCCID      string
+	pruAllowedCCID string
+	exceptions     map[string]bool // set of exception logins (lower-cased)
+	log            *slog.Logger
+}
+
+// NewManager creates a PRU manager from the loaded configuration.
+func NewManager(cfg *config.Manager, logger *slog.Logger) *Manager {
+	exceptions := make(map[string]bool, len(cfg.PRUsExceptionUsers))
+	for _, u := range cfg.PRUsExceptionUsers {
+		exceptions[strings.ToLower(u)] = true
+	}
+
+	logger.Info("Initialized PRU manager",
+		"exception_users", len(exceptions),
+		"no_pru_cc", cfg.NoPRUsCostCenterID,
+		"pru_allowed_cc", cfg.PRUsAllowedCostCenterID,
+	)
+
+	return &Manager{
+		noPRUCCID:      cfg.NoPRUsCostCenterID,
+		pruAllowedCCID: cfg.PRUsAllowedCostCenterID,
+		exceptions:     exceptions,
+		log:            logger,
+	}
+}
+
+// SetCostCenterIDs updates the cost center IDs at runtime (e.g. after
+// auto-creation resolves placeholders into real UUIDs).
+func (m *Manager) SetCostCenterIDs(noPRU, pruAllowed string) {
+	m.noPRUCCID = noPRU
+	m.pruAllowedCCID = pruAllowed
+	m.log.Info("Updated cost center IDs", "no_pru", noPRU, "pru_allowed", pruAllowed)
+}
+
+// NoPRUCCID returns the current no-PRU cost center ID.
+func (m *Manager) NoPRUCCID() string { return m.noPRUCCID }
+
+// PRUAllowedCCID returns the current PRU-allowed cost center ID.
+func (m *Manager) PRUAllowedCCID() string { return m.pruAllowedCCID }
+
+// IsException returns true if the login is in the PRU exception list.
+func (m *Manager) IsException(login string) bool {
+	return m.exceptions[strings.ToLower(login)]
+}
+
+// AssignCostCenter returns the cost center ID for a given user.
+//
+//	exception user → pru_allowed_cost_center_id
+//	everyone else  → no_prus_cost_center_id
+func (m *Manager) AssignCostCenter(user github.CopilotUser) string {
+	if m.IsException(user.Login) {
+		m.log.Debug("User is PRU exception", "user", user.Login, "cc", m.pruAllowedCCID)
+		return m.pruAllowedCCID
+	}
+	m.log.Debug("User assigned to default CC", "user", user.Login, "cc", m.noPRUCCID)
+	return m.noPRUCCID
+}
+
+// AssignmentGroups builds the desired {cost_center_id: [usernames]} map for a
+// list of users.
+func (m *Manager) AssignmentGroups(users []github.CopilotUser) map[string][]string {
+	groups := map[string][]string{
+		m.pruAllowedCCID: {},
+		m.noPRUCCID:      {},
+	}
+	for _, u := range users {
+		cc := m.AssignCostCenter(u)
+		groups[cc] = append(groups[cc], u.Login)
+	}
+	return groups
+}
+
+// GenerateSummary returns a cost-center → user-count map for display.
+func (m *Manager) GenerateSummary(users []github.CopilotUser) map[string]int {
+	summary := make(map[string]int)
+	for _, u := range users {
+		cc := m.AssignCostCenter(u)
+		summary[cc]++
+	}
+	return summary
+}
+
+// ValidateConfiguration checks that the PRU configuration is usable and
+// returns a list of issues (empty = valid).
+func (m *Manager) ValidateConfiguration() []string {
+	var issues []string
+	if m.noPRUCCID == "" {
+		issues = append(issues, "no_prus_cost_center_id is not defined")
+	}
+	if m.pruAllowedCCID == "" {
+		issues = append(issues, "prus_allowed_cost_center_id is not defined")
+	}
+	if m.noPRUCCID != "" && m.noPRUCCID == m.pruAllowedCCID {
+		issues = append(issues, "no_prus_cost_center_id and prus_allowed_cost_center_id cannot be the same")
+	}
+	return issues
+}
+
+// PrintConfigSummary displays the current PRU configuration to stdout.
+func (m *Manager) PrintConfigSummary(cfg *config.Manager, autoCreate bool) {
+	fmt.Println()
+	fmt.Println("===== Current Configuration =====")
+	fmt.Printf("Enterprise: %s\n", cfg.Enterprise)
+
+	if autoCreate {
+		fmt.Printf("No PRUs Cost Center: New cost center %q to be created\n", cfg.NoPRUsCostCenterName)
+		fmt.Printf("PRUs Allowed Cost Center: New cost center %q to be created\n", cfg.PRUsAllowedCostCenterName)
+	} else {
+		fmt.Printf("No PRUs Cost Center: %s\n", m.noPRUCCID)
+		printCCURL(cfg.Enterprise, m.noPRUCCID)
+
+		fmt.Printf("PRUs Allowed Cost Center: %s\n", m.pruAllowedCCID)
+		printCCURL(cfg.Enterprise, m.pruAllowedCCID)
+	}
+
+	fmt.Printf("PRUs Exception Users (%d):\n", len(cfg.PRUsExceptionUsers))
+	for _, u := range cfg.PRUsExceptionUsers {
+		fmt.Printf("  - %s\n", u)
+	}
+	fmt.Println("===== End of Configuration =====")
+	fmt.Println()
+}
+
+// ShowSuccessSummary prints a comprehensive success summary at the end of a
+// run, including cost center URLs, user statistics, and assignment results.
+func ShowSuccessSummary(cfg *config.Manager, users []github.CopilotUser, originalCount *int, results map[string]map[string]bool, applied bool) {
+	fmt.Println()
+	fmt.Println(strings.Repeat("=", 60))
+	fmt.Println("SUCCESS SUMMARY")
+	fmt.Println(strings.Repeat("=", 60))
+
+	// Cost center links.
+	if cfg.Enterprise != "" && !strings.HasPrefix(cfg.Enterprise, "REPLACE_WITH_") {
+		fmt.Printf("\nCOST CENTERS (%s):\n", cfg.Enterprise)
+		if !strings.HasPrefix(cfg.NoPRUsCostCenterID, "REPLACE_WITH_") {
+			fmt.Printf("  No PRU Overages: %s\n", cfg.NoPRUsCostCenterID)
+			fmt.Printf("     -> https://github.com/enterprises/%s/billing/cost_centers/%s\n",
+				cfg.Enterprise, cfg.NoPRUsCostCenterID)
+		}
+		if !strings.HasPrefix(cfg.PRUsAllowedCostCenterID, "REPLACE_WITH_") {
+			fmt.Printf("  PRU Overages Allowed: %s\n", cfg.PRUsAllowedCostCenterID)
+			fmt.Printf("     -> https://github.com/enterprises/%s/billing/cost_centers/%s\n",
+				cfg.Enterprise, cfg.PRUsAllowedCostCenterID)
+		}
+	}
+
+	// User statistics.
+	if len(users) > 0 {
+		fmt.Printf("\nUSER STATISTICS:\n")
+		fmt.Printf("  Total users processed: %d\n", len(users))
+		if originalCount != nil {
+			fmt.Printf("  Incremental processing: %d of %d total users\n", len(users), *originalCount)
+		}
+
+		if results != nil && applied {
+			totalAttempted := 0
+			totalSuccessful := 0
+			for _, ccResults := range results {
+				for _, ok := range ccResults {
+					totalAttempted++
+					if ok {
+						totalSuccessful++
+					}
+				}
+			}
+			fmt.Printf("  Assignment success rate: %d/%d users\n", totalSuccessful, totalAttempted)
+			if totalSuccessful < totalAttempted {
+				fmt.Printf("  Failed assignments: %d users\n", totalAttempted-totalSuccessful)
+			}
+		}
+	}
+
+	fmt.Println(strings.Repeat("=", 60))
+}
+
+// printCCURL prints the cost center URL if the IDs are not placeholders.
+func printCCURL(enterprise, ccID string) {
+	if enterprise == "" || strings.HasPrefix(enterprise, "REPLACE_WITH_") {
+		return
+	}
+	if strings.HasPrefix(ccID, "REPLACE_WITH_") {
+		return
+	}
+	fmt.Printf("  -> https://github.com/enterprises/%s/billing/cost_centers/%s\n", enterprise, ccID)
+}

--- a/internal/pru/manager_test.go
+++ b/internal/pru/manager_test.go
@@ -1,0 +1,241 @@
+package pru
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/renan-alm/gh-cost-center/internal/config"
+	"github.com/renan-alm/gh-cost-center/internal/github"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func testConfig(noPRUID, pruAllowedID string, exceptions []string) *config.Manager {
+	return &config.Manager{
+		Enterprise:                "test-enterprise",
+		APIBaseURL:                "https://api.github.com",
+		NoPRUsCostCenterID:        noPRUID,
+		PRUsAllowedCostCenterID:   pruAllowedID,
+		PRUsExceptionUsers:        exceptions,
+		NoPRUsCostCenterName:      "No PRU",
+		PRUsAllowedCostCenterName: "PRU Allowed",
+	}
+}
+
+func TestAssignCostCenter_ExceptionUser(t *testing.T) {
+	cfg := testConfig("cc-no-pru", "cc-pru-allowed", []string{"alice", "bob"})
+	mgr := NewManager(cfg, testLogger())
+
+	user := github.CopilotUser{Login: "alice"}
+	got := mgr.AssignCostCenter(user)
+
+	if got != "cc-pru-allowed" {
+		t.Errorf("AssignCostCenter(alice) = %q; want %q", got, "cc-pru-allowed")
+	}
+}
+
+func TestAssignCostCenter_RegularUser(t *testing.T) {
+	cfg := testConfig("cc-no-pru", "cc-pru-allowed", []string{"alice"})
+	mgr := NewManager(cfg, testLogger())
+
+	user := github.CopilotUser{Login: "charlie"}
+	got := mgr.AssignCostCenter(user)
+
+	if got != "cc-no-pru" {
+		t.Errorf("AssignCostCenter(charlie) = %q; want %q", got, "cc-no-pru")
+	}
+}
+
+func TestAssignCostCenter_CaseInsensitive(t *testing.T) {
+	cfg := testConfig("cc-no-pru", "cc-pru-allowed", []string{"Alice"})
+	mgr := NewManager(cfg, testLogger())
+
+	tests := []struct {
+		login string
+		want  string
+	}{
+		{"alice", "cc-pru-allowed"},
+		{"ALICE", "cc-pru-allowed"},
+		{"Alice", "cc-pru-allowed"},
+		{"bob", "cc-no-pru"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.login, func(t *testing.T) {
+			got := mgr.AssignCostCenter(github.CopilotUser{Login: tt.login})
+			if got != tt.want {
+				t.Errorf("AssignCostCenter(%s) = %q; want %q", tt.login, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsException(t *testing.T) {
+	cfg := testConfig("cc1", "cc2", []string{"alice", "Bob"})
+	mgr := NewManager(cfg, testLogger())
+
+	if !mgr.IsException("alice") {
+		t.Error("IsException(alice) = false; want true")
+	}
+	if !mgr.IsException("ALICE") {
+		t.Error("IsException(ALICE) = false; want true")
+	}
+	if !mgr.IsException("bob") {
+		t.Error("IsException(bob) = false; want true")
+	}
+	if mgr.IsException("charlie") {
+		t.Error("IsException(charlie) = true; want false")
+	}
+}
+
+func TestAssignmentGroups(t *testing.T) {
+	cfg := testConfig("cc-no-pru", "cc-pru-allowed", []string{"alice"})
+	mgr := NewManager(cfg, testLogger())
+
+	users := []github.CopilotUser{
+		{Login: "alice"},
+		{Login: "bob"},
+		{Login: "charlie"},
+	}
+
+	groups := mgr.AssignmentGroups(users)
+
+	if len(groups["cc-pru-allowed"]) != 1 {
+		t.Errorf("PRU-allowed group has %d users; want 1", len(groups["cc-pru-allowed"]))
+	}
+	if groups["cc-pru-allowed"][0] != "alice" {
+		t.Errorf("PRU-allowed group[0] = %q; want alice", groups["cc-pru-allowed"][0])
+	}
+	if len(groups["cc-no-pru"]) != 2 {
+		t.Errorf("No-PRU group has %d users; want 2", len(groups["cc-no-pru"]))
+	}
+}
+
+func TestAssignmentGroups_NoExceptions(t *testing.T) {
+	cfg := testConfig("cc-no-pru", "cc-pru-allowed", []string{})
+	mgr := NewManager(cfg, testLogger())
+
+	users := []github.CopilotUser{
+		{Login: "alice"},
+		{Login: "bob"},
+	}
+
+	groups := mgr.AssignmentGroups(users)
+
+	if len(groups["cc-pru-allowed"]) != 0 {
+		t.Errorf("PRU-allowed group has %d users; want 0", len(groups["cc-pru-allowed"]))
+	}
+	if len(groups["cc-no-pru"]) != 2 {
+		t.Errorf("No-PRU group has %d users; want 2", len(groups["cc-no-pru"]))
+	}
+}
+
+func TestAssignmentGroups_AllExceptions(t *testing.T) {
+	cfg := testConfig("cc-no-pru", "cc-pru-allowed", []string{"alice", "bob"})
+	mgr := NewManager(cfg, testLogger())
+
+	users := []github.CopilotUser{
+		{Login: "alice"},
+		{Login: "bob"},
+	}
+
+	groups := mgr.AssignmentGroups(users)
+
+	if len(groups["cc-pru-allowed"]) != 2 {
+		t.Errorf("PRU-allowed group has %d users; want 2", len(groups["cc-pru-allowed"]))
+	}
+	if len(groups["cc-no-pru"]) != 0 {
+		t.Errorf("No-PRU group has %d users; want 0", len(groups["cc-no-pru"]))
+	}
+}
+
+func TestGenerateSummary(t *testing.T) {
+	cfg := testConfig("cc-no-pru", "cc-pru-allowed", []string{"alice"})
+	mgr := NewManager(cfg, testLogger())
+
+	users := []github.CopilotUser{
+		{Login: "alice"},
+		{Login: "bob"},
+		{Login: "charlie"},
+		{Login: "dave"},
+	}
+
+	summary := mgr.GenerateSummary(users)
+
+	if summary["cc-pru-allowed"] != 1 {
+		t.Errorf("summary[cc-pru-allowed] = %d; want 1", summary["cc-pru-allowed"])
+	}
+	if summary["cc-no-pru"] != 3 {
+		t.Errorf("summary[cc-no-pru] = %d; want 3", summary["cc-no-pru"])
+	}
+}
+
+func TestGenerateSummary_Empty(t *testing.T) {
+	cfg := testConfig("cc-no-pru", "cc-pru-allowed", []string{})
+	mgr := NewManager(cfg, testLogger())
+
+	summary := mgr.GenerateSummary(nil)
+
+	if len(summary) != 0 {
+		t.Errorf("summary has %d entries; want 0", len(summary))
+	}
+}
+
+func TestValidateConfiguration(t *testing.T) {
+	tests := []struct {
+		name       string
+		noPRU      string
+		pruAllowed string
+		wantIssues int
+	}{
+		{"valid", "cc1", "cc2", 0},
+		{"missing_no_pru", "", "cc2", 1},
+		{"missing_pru_allowed", "cc1", "", 1},
+		{"both_missing", "", "", 2},
+		{"same_ids", "cc1", "cc1", 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := testConfig(tt.noPRU, tt.pruAllowed, nil)
+			mgr := NewManager(cfg, testLogger())
+			issues := mgr.ValidateConfiguration()
+			if len(issues) != tt.wantIssues {
+				t.Errorf("ValidateConfiguration() returned %d issues; want %d: %v",
+					len(issues), tt.wantIssues, issues)
+			}
+		})
+	}
+}
+
+func TestSetCostCenterIDs(t *testing.T) {
+	cfg := testConfig("old-no-pru", "old-pru-allowed", []string{})
+	mgr := NewManager(cfg, testLogger())
+
+	mgr.SetCostCenterIDs("new-no-pru", "new-pru-allowed")
+
+	user := github.CopilotUser{Login: "alice"}
+	got := mgr.AssignCostCenter(user)
+	if got != "new-no-pru" {
+		t.Errorf("after SetCostCenterIDs, AssignCostCenter = %q; want new-no-pru", got)
+	}
+
+	if mgr.NoPRUCCID() != "new-no-pru" {
+		t.Errorf("NoPRUCCID() = %q; want new-no-pru", mgr.NoPRUCCID())
+	}
+	if mgr.PRUAllowedCCID() != "new-pru-allowed" {
+		t.Errorf("PRUAllowedCCID() = %q; want new-pru-allowed", mgr.PRUAllowedCCID())
+	}
+}
+
+func TestNewManager_NilExceptions(t *testing.T) {
+	cfg := testConfig("cc1", "cc2", nil)
+	mgr := NewManager(cfg, testLogger())
+
+	if mgr.IsException("anyone") {
+		t.Error("IsException should return false when exception list is nil")
+	}
+}


### PR DESCRIPTION
## PR 4: PRU-Based Mode (Default)

Port the core PRU-based cost center assignment flow — the default mode when no `--teams` or `--repo` flags are specified.

### New Files

- **`internal/pru/manager.go`** — PRU manager with:
  - `AssignCostCenter(user)` — exception users → `pru_allowed` CC, others → `no_pru` CC
  - `AssignmentGroups(users)` — builds `{cc_id: [usernames]}` map
  - `GenerateSummary(users)` — cost center → count map
  - `ValidateConfiguration()` — checks for empty/same IDs
  - `PrintConfigSummary()` / `ShowSuccessSummary()` — config and results display with CC URLs
  - Case-insensitive exception matching via lowercase map

- **`internal/pru/manager_test.go`** — 12 test functions:
  - `TestAssignCostCenter_ExceptionUser`, `_RegularUser`, `_CaseInsensitive`
  - `TestIsException` (case-insensitive matching)
  - `TestAssignmentGroups`, `_NoExceptions`, `_AllExceptions`
  - `TestGenerateSummary`, `_Empty`
  - `TestValidateConfiguration` (table-driven: 5 cases)
  - `TestSetCostCenterIDs`, `TestNewManager_NilExceptions`

### Modified Files

- **`cmd/assign.go`** — Full PRU assignment flow:
  - Plan mode: preview assignments without making changes
  - Apply mode: confirmation prompt (`type 'apply'` unless `--yes`)
  - `--create-cost-centers`: auto-create CCs via `EnsureCostCentersExist()`
  - `--incremental`: filter users by `created_at > last_run_timestamp`
  - `--users`: comma-separated login filter
  - `BulkUpdateCostCenterAssignments()` with batches of 50
  - Per-CC and overall success/fail result tracking
  - Incremental timestamp save on successful apply

- **`cmd/list_users.go`** — Fetch Copilot users, display with `[PRUs Exception]` markers

- **`cmd/report.go`** — Generate and display cost center summary (CC → user count)

### Verification

```bash
go test -race ./...                          # all tests pass
go vet ./...                                 # clean
golangci-lint run                            # 0 issues
gh cost-center assign --mode plan            # preview assignments
gh cost-center list-users                    # shows users with PRU markers
gh cost-center report                        # shows summary
```