### PR TITLE
feat: add repository mode and budget creation (PR 6/8)

### DIFF
--- a/internal/budgets/manager.go
+++ b/internal/budgets/manager.go
@@ -1,0 +1,67 @@
+// Package budgets provides helper functions for creating product budgets for
+// newly-created cost centers.  It wraps the lower-level github.Client budget
+// operations and handles the case where the Budgets API is unavailable.
+package budgets
+
+import (
+	"log/slog"
+
+	"github.com/renan-alm/gh-cost-center/internal/config"
+	"github.com/renan-alm/gh-cost-center/internal/github"
+)
+
+// Manager orchestrates product-budget creation for cost centers.
+type Manager struct {
+	client      *github.Client
+	log         *slog.Logger
+	products    map[string]config.ProductBudget
+	unavailable bool
+}
+
+// NewManager creates a budget manager from a GitHub client, logger, and product budget map.
+func NewManager(client *github.Client, logger *slog.Logger, products map[string]config.ProductBudget) *Manager {
+	return &Manager{
+		client:   client,
+		log:      logger,
+		products: products,
+	}
+}
+
+// IsAvailable returns false once the budgets API has been detected as unavailable.
+func (m *Manager) IsAvailable() bool {
+	return !m.unavailable
+}
+
+// EnsureBudgetsForCostCenter creates all enabled product budgets for a cost center.
+// If the budgets API is unavailable, it sets a flag and returns early.
+func (m *Manager) EnsureBudgetsForCostCenter(ccID, ccName string) {
+	if m.unavailable {
+		return
+	}
+
+	m.log.Info("Creating budgets for cost center", "name", ccName)
+
+	for product, pc := range m.products {
+		if !pc.Enabled {
+			m.log.Debug("Skipping disabled product budget", "product", product)
+			continue
+		}
+
+		ok, err := m.client.CreateProductBudget(ccID, ccName, product, pc.Amount)
+		if err != nil {
+			if _, uaErr := err.(*github.BudgetsAPIUnavailableError); uaErr {
+				m.log.Warn("Budgets API unavailable, disabling budget creation",
+					"error", err)
+				m.unavailable = true
+				return
+			}
+			m.log.Error("Failed to create budget",
+				"product", product, "cost_center", ccName, "error", err)
+			continue
+		}
+		if ok {
+			m.log.Info("Budget created",
+				"product", product, "cost_center", ccName, "amount", pc.Amount)
+		}
+	}
+}

--- a/internal/budgets/manager_test.go
+++ b/internal/budgets/manager_test.go
@@ -1,0 +1,56 @@
+package budgets
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/renan-alm/gh-cost-center/internal/config"
+)
+
+func TestNewManager(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	products := map[string]config.ProductBudget{
+		"actions": {Amount: 100, Enabled: true},
+		"copilot": {Amount: 200, Enabled: false},
+	}
+
+	mgr := NewManager(nil, logger, products)
+	if mgr == nil {
+		t.Fatal("expected non-nil manager")
+	}
+	if len(mgr.products) != 2 {
+		t.Errorf("expected 2 products, got %d", len(mgr.products))
+	}
+}
+
+func TestIsAvailable_Initially(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	mgr := NewManager(nil, logger, nil)
+
+	if !mgr.IsAvailable() {
+		t.Error("expected IsAvailable() == true initially")
+	}
+}
+
+func TestIsAvailable_AfterUnavailable(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	mgr := NewManager(nil, logger, nil)
+	mgr.unavailable = true
+
+	if mgr.IsAvailable() {
+		t.Error("expected IsAvailable() == false after marking unavailable")
+	}
+}
+
+func TestEnsureBudgets_SkipsWhenUnavailable(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	products := map[string]config.ProductBudget{
+		"actions": {Amount: 100, Enabled: true},
+	}
+	mgr := NewManager(nil, logger, products)
+	mgr.unavailable = true
+
+	// Should return immediately without panic (no client set).
+	mgr.EnsureBudgetsForCostCenter("cc-id-1", "Test CC")
+}

--- a/internal/repository/manager.go
+++ b/internal/repository/manager.go
@@ -1,0 +1,356 @@
+// Package repository implements repository-based cost center assignment for
+// GitHub Enterprise using custom properties to map repos to cost centers.
+package repository
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/renan-alm/gh-cost-center/internal/config"
+	"github.com/renan-alm/gh-cost-center/internal/github"
+)
+
+// MappingResult records the outcome of processing a single explicit mapping.
+type MappingResult struct {
+	CostCenter     string
+	CostCenterID   string
+	PropertyName   string
+	PropertyValues []string
+	ReposMatched   int
+	ReposAssigned  int
+	Success        bool
+	Message        string
+}
+
+// Summary holds the overall result of a repository assignment run.
+type Summary struct {
+	TotalRepos      int
+	MappingsTotal   int
+	MappingsApplied int
+	MappingResults  []MappingResult
+}
+
+// Print displays the summary to stdout.
+func (s *Summary) Print() {
+	fmt.Println()
+	fmt.Println(strings.Repeat("=", 80))
+	fmt.Println("REPOSITORY ASSIGNMENT SUMMARY")
+	fmt.Println(strings.Repeat("=", 80))
+	fmt.Printf("Total repositories in organization: %d\n", s.TotalRepos)
+	fmt.Printf("Mappings processed: %d / %d\n", s.MappingsApplied, s.MappingsTotal)
+
+	for _, r := range s.MappingResults {
+		fmt.Println()
+		fmt.Printf("Cost Center: %s\n", r.CostCenter)
+		fmt.Printf("  Property:  %s\n", r.PropertyName)
+		fmt.Printf("  Values:    %s\n", strings.Join(r.PropertyValues, ", "))
+		fmt.Printf("  Matched:   %d repositories\n", r.ReposMatched)
+		fmt.Printf("  Assigned:  %d repositories\n", r.ReposAssigned)
+		if r.Success {
+			fmt.Println("  Status:    Success")
+		} else {
+			fmt.Printf("  Status:    Failed \u2014 %s\n", r.Message)
+		}
+	}
+	fmt.Println(strings.Repeat("=", 80))
+}
+
+// Manager handles repository-based cost center assignment.
+type Manager struct {
+	cfg      *config.Manager
+	client   *github.Client
+	log      *slog.Logger
+	mappings []config.ExplicitMapping
+}
+
+// NewManager creates a new repository manager from configuration.
+func NewManager(cfg *config.Manager, client *github.Client, logger *slog.Logger) (*Manager, error) {
+	if cfg.RepositoryConfig == nil {
+		return nil, fmt.Errorf("repository mode requires 'repository_config' in configuration")
+	}
+	if len(cfg.RepositoryConfig.ExplicitMappings) == 0 {
+		return nil, fmt.Errorf("repository mode requires at least one explicit mapping in repository_config")
+	}
+	return &Manager{
+		cfg:      cfg,
+		client:   client,
+		log:      logger,
+		mappings: cfg.RepositoryConfig.ExplicitMappings,
+	}, nil
+}
+
+// ValidateConfiguration checks mapping definitions and returns any issues.
+func (m *Manager) ValidateConfiguration() []string {
+	var issues []string
+	for i, mp := range m.mappings {
+		if mp.CostCenter == "" {
+			issues = append(issues, fmt.Sprintf("mapping %d: missing cost_center", i+1))
+		}
+		if mp.PropertyName == "" {
+			issues = append(issues, fmt.Sprintf("mapping %d: missing property_name", i+1))
+		}
+		if len(mp.PropertyValues) == 0 {
+			issues = append(issues, fmt.Sprintf("mapping %d: missing property_values", i+1))
+		}
+	}
+	return issues
+}
+
+// PrintConfigSummary displays the repository mode configuration.
+func (m *Manager) PrintConfigSummary(org string) {
+	fmt.Println()
+	fmt.Println(strings.Repeat("=", 80))
+	fmt.Println("Repository-Based Cost Center Assignment")
+	fmt.Println(strings.Repeat("=", 80))
+	fmt.Printf("Organization: %s\n", org)
+	fmt.Printf("Mappings:     %d\n", len(m.mappings))
+	for i, mp := range m.mappings {
+		fmt.Printf("\n  Mapping %d:\n", i+1)
+		fmt.Printf("    Cost Center:    %s\n", mp.CostCenter)
+		fmt.Printf("    Property:       %s\n", mp.PropertyName)
+		fmt.Printf("    Values:         %s\n", strings.Join(mp.PropertyValues, ", "))
+	}
+	fmt.Println(strings.Repeat("=", 80))
+}
+
+// Run executes the full repository-based assignment flow.
+// mode is "plan" or "apply".  createBudgets enables budget creation for new CCs.
+func (m *Manager) Run(org, mode string, createBudgets bool) (*Summary, error) {
+	m.log.Info("Starting repository-based cost center assignment",
+		"org", org, "mode", mode, "mappings", len(m.mappings))
+
+	// Fetch all repos with custom properties.
+	m.log.Info("Fetching repositories with custom properties...", "org", org)
+	allRepos, err := m.client.GetOrgReposWithProperties(org, "")
+	if err != nil {
+		return nil, fmt.Errorf("fetching repos with properties: %w", err)
+	}
+	if len(allRepos) == 0 {
+		m.log.Warn("No repositories found", "org", org)
+		return &Summary{TotalRepos: 0, MappingsTotal: len(m.mappings)}, nil
+	}
+	m.log.Info("Repositories found", "org", org, "count", len(allRepos))
+
+	// Preload existing cost centers for efficient lookups.
+	activeCCs, err := m.client.GetAllActiveCostCenters()
+	if err != nil {
+		return nil, fmt.Errorf("fetching active cost centers: %w", err)
+	}
+	m.log.Info("Existing cost centers loaded", "count", len(activeCCs))
+
+	summary := &Summary{
+		TotalRepos:    len(allRepos),
+		MappingsTotal: len(m.mappings),
+	}
+
+	// Process each mapping.
+	for i, mp := range m.mappings {
+		m.log.Info("Processing mapping",
+			"index", i+1, "total", len(m.mappings),
+			"cost_center", mp.CostCenter,
+			"property", mp.PropertyName,
+			"values", strings.Join(mp.PropertyValues, ","))
+
+		result := m.processMapping(mp, allRepos, activeCCs, mode, createBudgets)
+		if result.Success {
+			summary.MappingsApplied++
+		}
+		summary.MappingResults = append(summary.MappingResults, result)
+	}
+
+	return summary, nil
+}
+
+// processMapping handles a single explicit mapping -- find matching repos,
+// ensure CC exists, and assign.
+func (m *Manager) processMapping(
+	mp config.ExplicitMapping,
+	allRepos []github.RepoProperties,
+	activeCCs map[string]string,
+	mode string,
+	createBudgets bool,
+) MappingResult {
+	result := MappingResult{
+		CostCenter:     mp.CostCenter,
+		PropertyName:   mp.PropertyName,
+		PropertyValues: mp.PropertyValues,
+	}
+
+	// Validate mapping fields.
+	if mp.CostCenter == "" || mp.PropertyName == "" || len(mp.PropertyValues) == 0 {
+		result.Message = "invalid mapping: missing cost_center, property_name, or property_values"
+		m.log.Error("Invalid mapping configuration", "cost_center", mp.CostCenter)
+		return result
+	}
+
+	// Find matching repos.
+	matching := findMatchingRepos(allRepos, mp.PropertyName, mp.PropertyValues)
+	result.ReposMatched = len(matching)
+
+	if len(matching) == 0 {
+		result.Message = "no matching repositories found"
+		m.log.Warn("No repos matched",
+			"cost_center", mp.CostCenter,
+			"property", mp.PropertyName,
+			"values", strings.Join(mp.PropertyValues, ","))
+		return result
+	}
+
+	m.log.Info("Repositories matched",
+		"cost_center", mp.CostCenter, "count", len(matching))
+
+	// Plan mode -- just report what would happen.
+	if mode == "plan" {
+		result.ReposAssigned = len(matching)
+		result.Success = true
+		result.Message = fmt.Sprintf("would assign %d repositories (plan mode)", len(matching))
+
+		m.log.Info("MODE=plan: would assign repos",
+			"cost_center", mp.CostCenter, "count", len(matching))
+		for _, r := range matching {
+			m.log.Debug("Would assign", "repo", r.RepositoryFullName, "cost_center", mp.CostCenter)
+		}
+		return result
+	}
+
+	// Apply mode -- ensure CC exists.
+	ccID, ok := activeCCs[mp.CostCenter]
+	if !ok {
+		m.log.Info("Cost center does not exist, creating...", "name", mp.CostCenter)
+		var err error
+		ccID, err = m.client.CreateCostCenterWithPreload(mp.CostCenter, activeCCs)
+		if err != nil {
+			result.Message = fmt.Sprintf("failed to create cost center: %v", err)
+			m.log.Error("Failed to create cost center",
+				"name", mp.CostCenter, "error", err)
+			return result
+		}
+		activeCCs[mp.CostCenter] = ccID
+		m.log.Info("Created cost center", "name", mp.CostCenter, "id", ccID)
+
+		// Create budgets if enabled.
+		if createBudgets && m.cfg.BudgetsEnabled {
+			m.createBudgets(ccID, mp.CostCenter)
+		}
+	} else {
+		m.log.Info("Cost center already exists", "name", mp.CostCenter, "id", ccID)
+	}
+
+	result.CostCenterID = ccID
+
+	// Extract repo full names.
+	repoNames := make([]string, 0, len(matching))
+	for _, r := range matching {
+		if r.RepositoryFullName != "" {
+			repoNames = append(repoNames, r.RepositoryFullName)
+		} else {
+			m.log.Warn("Repository missing full name, skipping", "name", r.RepositoryName)
+		}
+	}
+
+	if len(repoNames) == 0 {
+		result.Message = "no valid repository names to assign"
+		m.log.Error("No valid repo names", "cost_center", mp.CostCenter)
+		return result
+	}
+
+	// Log repos being assigned.
+	for i, name := range repoNames {
+		if i < 10 {
+			m.log.Info("Assigning repo", "repo", name, "cost_center", mp.CostCenter)
+		}
+	}
+	if len(repoNames) > 10 {
+		m.log.Info("...and more", "remaining", len(repoNames)-10)
+	}
+
+	// Call API to assign repos.
+	if err := m.client.AddRepositoriesToCostCenter(ccID, repoNames); err != nil {
+		result.Message = fmt.Sprintf("failed to assign repos: %v", err)
+		m.log.Error("Failed to assign repos",
+			"cost_center", mp.CostCenter, "error", err)
+		return result
+	}
+
+	result.ReposAssigned = len(repoNames)
+	result.Success = true
+	result.Message = fmt.Sprintf("successfully assigned %d/%d repositories",
+		len(repoNames), len(matching))
+	m.log.Info("Successfully assigned repos",
+		"cost_center", mp.CostCenter, "assigned", len(repoNames))
+
+	return result
+}
+
+// createBudgets creates configured budgets for a single cost center.
+func (m *Manager) createBudgets(ccID, ccName string) {
+	m.log.Info("Creating budgets for cost center", "name", ccName)
+
+	for product, pc := range m.cfg.BudgetProducts {
+		if !pc.Enabled {
+			m.log.Debug("Skipping disabled product budget", "product", product)
+			continue
+		}
+
+		ok, err := m.client.CreateProductBudget(ccID, ccName, product, pc.Amount)
+		if err != nil {
+			// If budgets API is unavailable, log and stop trying.
+			if _, unavailable := err.(*github.BudgetsAPIUnavailableError); unavailable {
+				m.log.Warn("Budgets API unavailable, skipping remaining budgets",
+					"error", err)
+				return
+			}
+			m.log.Error("Failed to create budget",
+				"product", product, "cost_center", ccName, "error", err)
+			continue
+		}
+		if ok {
+			m.log.Info("Budget created",
+				"product", product, "cost_center", ccName, "amount", pc.Amount)
+		}
+	}
+}
+
+// findMatchingRepos returns repos whose custom properties match the mapping criteria.
+func findMatchingRepos(
+	repos []github.RepoProperties,
+	propertyName string,
+	propertyValues []string,
+) []github.RepoProperties {
+	valueSet := make(map[string]bool, len(propertyValues))
+	for _, v := range propertyValues {
+		valueSet[v] = true
+	}
+
+	var matched []github.RepoProperties
+	for _, repo := range repos {
+		for _, prop := range repo.Properties {
+			if prop.PropertyName != propertyName {
+				continue
+			}
+			// Property value can be a string or []string.
+			if matchesValue(prop.Value, valueSet) {
+				matched = append(matched, repo)
+				break
+			}
+		}
+	}
+	return matched
+}
+
+// matchesValue checks if a property value (string or []any) matches any value
+// in the allowed set.
+func matchesValue(val any, allowed map[string]bool) bool {
+	switch v := val.(type) {
+	case string:
+		return allowed[v]
+	case []any:
+		for _, item := range v {
+			if s, ok := item.(string); ok && allowed[s] {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/repository/manager_test.go
+++ b/internal/repository/manager_test.go
@@ -1,0 +1,367 @@
+package repository
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/renan-alm/gh-cost-center/internal/config"
+	"github.com/renan-alm/gh-cost-center/internal/github"
+)
+
+// newTestManager builds a Manager with test defaults.
+func newTestManager(mappings []config.ExplicitMapping) *Manager {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	cfg := &config.Manager{
+		RepositoryConfig: &config.RepositoryConfig{
+			ExplicitMappings: mappings,
+		},
+		BudgetsEnabled: false,
+	}
+	return &Manager{
+		cfg:      cfg,
+		log:      logger,
+		mappings: mappings,
+	}
+}
+
+// --- NewManager tests ---
+
+func TestNewManager_NilConfig(t *testing.T) {
+	cfg := &config.Manager{}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	_, err := NewManager(cfg, nil, logger)
+	if err == nil {
+		t.Fatal("expected error for nil RepositoryConfig")
+	}
+}
+
+func TestNewManager_NoMappings(t *testing.T) {
+	cfg := &config.Manager{
+		RepositoryConfig: &config.RepositoryConfig{
+			ExplicitMappings: nil,
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	_, err := NewManager(cfg, nil, logger)
+	if err == nil {
+		t.Fatal("expected error for empty mappings")
+	}
+}
+
+func TestNewManager_Valid(t *testing.T) {
+	cfg := &config.Manager{
+		RepositoryConfig: &config.RepositoryConfig{
+			ExplicitMappings: []config.ExplicitMapping{
+				{CostCenter: "cc1", PropertyName: "team", PropertyValues: []string{"eng"}},
+			},
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	mgr, err := NewManager(cfg, nil, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(mgr.mappings) != 1 {
+		t.Errorf("expected 1 mapping, got %d", len(mgr.mappings))
+	}
+}
+
+// --- ValidateConfiguration tests ---
+
+func TestValidateConfiguration_AllValid(t *testing.T) {
+	mgr := newTestManager([]config.ExplicitMapping{
+		{CostCenter: "cc1", PropertyName: "team", PropertyValues: []string{"eng"}},
+		{CostCenter: "cc2", PropertyName: "dept", PropertyValues: []string{"sales", "marketing"}},
+	})
+
+	issues := mgr.ValidateConfiguration()
+	if len(issues) != 0 {
+		t.Errorf("expected no issues, got %v", issues)
+	}
+}
+
+func TestValidateConfiguration_MissingCostCenter(t *testing.T) {
+	mgr := newTestManager([]config.ExplicitMapping{
+		{CostCenter: "", PropertyName: "team", PropertyValues: []string{"eng"}},
+	})
+
+	issues := mgr.ValidateConfiguration()
+	if len(issues) != 1 {
+		t.Errorf("expected 1 issue, got %d: %v", len(issues), issues)
+	}
+}
+
+func TestValidateConfiguration_MissingPropertyName(t *testing.T) {
+	mgr := newTestManager([]config.ExplicitMapping{
+		{CostCenter: "cc1", PropertyName: "", PropertyValues: []string{"eng"}},
+	})
+
+	issues := mgr.ValidateConfiguration()
+	if len(issues) != 1 {
+		t.Errorf("expected 1 issue, got %d: %v", len(issues), issues)
+	}
+}
+
+func TestValidateConfiguration_MissingPropertyValues(t *testing.T) {
+	mgr := newTestManager([]config.ExplicitMapping{
+		{CostCenter: "cc1", PropertyName: "team", PropertyValues: nil},
+	})
+
+	issues := mgr.ValidateConfiguration()
+	if len(issues) != 1 {
+		t.Errorf("expected 1 issue, got %d: %v", len(issues), issues)
+	}
+}
+
+func TestValidateConfiguration_MultipleIssues(t *testing.T) {
+	mgr := newTestManager([]config.ExplicitMapping{
+		{CostCenter: "", PropertyName: "", PropertyValues: nil},
+	})
+
+	issues := mgr.ValidateConfiguration()
+	if len(issues) != 3 {
+		t.Errorf("expected 3 issues, got %d: %v", len(issues), issues)
+	}
+}
+
+// --- findMatchingRepos tests ---
+
+func TestFindMatchingRepos_StringValue(t *testing.T) {
+	repos := []github.RepoProperties{
+		{
+			RepositoryName:     "repo1",
+			RepositoryFullName: "org/repo1",
+			Properties: []github.Property{
+				{PropertyName: "team", Value: "engineering"},
+			},
+		},
+		{
+			RepositoryName:     "repo2",
+			RepositoryFullName: "org/repo2",
+			Properties: []github.Property{
+				{PropertyName: "team", Value: "sales"},
+			},
+		},
+		{
+			RepositoryName:     "repo3",
+			RepositoryFullName: "org/repo3",
+			Properties: []github.Property{
+				{PropertyName: "team", Value: "engineering"},
+			},
+		},
+	}
+
+	matched := findMatchingRepos(repos, "team", []string{"engineering"})
+	if len(matched) != 2 {
+		t.Errorf("expected 2 matches, got %d", len(matched))
+	}
+}
+
+func TestFindMatchingRepos_ArrayValue(t *testing.T) {
+	repos := []github.RepoProperties{
+		{
+			RepositoryName:     "repo1",
+			RepositoryFullName: "org/repo1",
+			Properties: []github.Property{
+				{PropertyName: "tags", Value: []any{"go", "backend"}},
+			},
+		},
+		{
+			RepositoryName:     "repo2",
+			RepositoryFullName: "org/repo2",
+			Properties: []github.Property{
+				{PropertyName: "tags", Value: []any{"python", "frontend"}},
+			},
+		},
+	}
+
+	matched := findMatchingRepos(repos, "tags", []string{"go"})
+	if len(matched) != 1 {
+		t.Errorf("expected 1 match, got %d", len(matched))
+	}
+	if matched[0].RepositoryName != "repo1" {
+		t.Errorf("expected repo1, got %s", matched[0].RepositoryName)
+	}
+}
+
+func TestFindMatchingRepos_MultipleValues(t *testing.T) {
+	repos := []github.RepoProperties{
+		{
+			RepositoryName:     "repo1",
+			RepositoryFullName: "org/repo1",
+			Properties: []github.Property{
+				{PropertyName: "team", Value: "engineering"},
+			},
+		},
+		{
+			RepositoryName:     "repo2",
+			RepositoryFullName: "org/repo2",
+			Properties: []github.Property{
+				{PropertyName: "team", Value: "sales"},
+			},
+		},
+		{
+			RepositoryName:     "repo3",
+			RepositoryFullName: "org/repo3",
+			Properties: []github.Property{
+				{PropertyName: "team", Value: "devops"},
+			},
+		},
+	}
+
+	matched := findMatchingRepos(repos, "team", []string{"engineering", "devops"})
+	if len(matched) != 2 {
+		t.Errorf("expected 2 matches, got %d", len(matched))
+	}
+}
+
+func TestFindMatchingRepos_NoMatch(t *testing.T) {
+	repos := []github.RepoProperties{
+		{
+			RepositoryName:     "repo1",
+			RepositoryFullName: "org/repo1",
+			Properties: []github.Property{
+				{PropertyName: "team", Value: "sales"},
+			},
+		},
+	}
+
+	matched := findMatchingRepos(repos, "team", []string{"engineering"})
+	if len(matched) != 0 {
+		t.Errorf("expected 0 matches, got %d", len(matched))
+	}
+}
+
+func TestFindMatchingRepos_DifferentPropertyName(t *testing.T) {
+	repos := []github.RepoProperties{
+		{
+			RepositoryName:     "repo1",
+			RepositoryFullName: "org/repo1",
+			Properties: []github.Property{
+				{PropertyName: "dept", Value: "engineering"},
+			},
+		},
+	}
+
+	matched := findMatchingRepos(repos, "team", []string{"engineering"})
+	if len(matched) != 0 {
+		t.Errorf("should not match different property name, got %d", len(matched))
+	}
+}
+
+func TestFindMatchingRepos_NoProperties(t *testing.T) {
+	repos := []github.RepoProperties{
+		{
+			RepositoryName:     "repo1",
+			RepositoryFullName: "org/repo1",
+			Properties:         nil,
+		},
+	}
+
+	matched := findMatchingRepos(repos, "team", []string{"engineering"})
+	if len(matched) != 0 {
+		t.Errorf("expected 0 matches for repo with no properties, got %d", len(matched))
+	}
+}
+
+// --- matchesValue tests ---
+
+func TestMatchesValue_StringMatch(t *testing.T) {
+	allowed := map[string]bool{"eng": true, "devops": true}
+	if !matchesValue("eng", allowed) {
+		t.Error("expected true for matching string")
+	}
+}
+
+func TestMatchesValue_StringNoMatch(t *testing.T) {
+	allowed := map[string]bool{"eng": true}
+	if matchesValue("sales", allowed) {
+		t.Error("expected false for non-matching string")
+	}
+}
+
+func TestMatchesValue_ArrayMatch(t *testing.T) {
+	allowed := map[string]bool{"go": true}
+	val := []any{"python", "go", "javascript"}
+	if !matchesValue(val, allowed) {
+		t.Error("expected true for array containing matching value")
+	}
+}
+
+func TestMatchesValue_ArrayNoMatch(t *testing.T) {
+	allowed := map[string]bool{"rust": true}
+	val := []any{"python", "go"}
+	if matchesValue(val, allowed) {
+		t.Error("expected false for array not containing matching value")
+	}
+}
+
+func TestMatchesValue_NilValue(t *testing.T) {
+	allowed := map[string]bool{"eng": true}
+	if matchesValue(nil, allowed) {
+		t.Error("expected false for nil value")
+	}
+}
+
+func TestMatchesValue_IntValue(t *testing.T) {
+	allowed := map[string]bool{"eng": true}
+	if matchesValue(42, allowed) {
+		t.Error("expected false for int value")
+	}
+}
+
+func TestMatchesValue_EmptyArray(t *testing.T) {
+	allowed := map[string]bool{"eng": true}
+	val := []any{}
+	if matchesValue(val, allowed) {
+		t.Error("expected false for empty array")
+	}
+}
+
+// --- Summary.Print test ---
+
+func TestSummaryPrint(t *testing.T) {
+	s := &Summary{
+		TotalRepos:      10,
+		MappingsTotal:   2,
+		MappingsApplied: 1,
+		MappingResults: []MappingResult{
+			{
+				CostCenter:     "cc1",
+				PropertyName:   "team",
+				PropertyValues: []string{"eng"},
+				ReposMatched:   5,
+				ReposAssigned:  5,
+				Success:        true,
+				Message:        "ok",
+			},
+			{
+				CostCenter:     "cc2",
+				PropertyName:   "team",
+				PropertyValues: []string{"sales"},
+				ReposMatched:   0,
+				ReposAssigned:  0,
+				Success:        false,
+				Message:        "no repos matched",
+			},
+		},
+	}
+	// Just verify it does not panic.
+	s.Print()
+}
+
+// --- PrintConfigSummary test ---
+
+func TestPrintConfigSummary(t *testing.T) {
+	mgr := newTestManager([]config.ExplicitMapping{
+		{CostCenter: "cc1", PropertyName: "team", PropertyValues: []string{"eng"}},
+		{CostCenter: "cc2", PropertyName: "dept", PropertyValues: []string{"sales", "marketing"}},
+	})
+
+	// Just verify it does not panic.
+	mgr.PrintConfigSummary("test-org")
+}


### PR DESCRIPTION
- Add internal/repository/manager.go: repository-based cost center assignment using custom properties with explicit mappings
- Add internal/budgets/manager.go: budget orchestration with BudgetsAPIUnavailableError handling and unavailability detection
- Wire --repo flag in cmd/assign.go with plan/apply modes
- Wire --create-budgets into teams assignment flow
- Add comprehensive unit tests for both packages (26 tests)