### PR TITLE
feat: Cache System + Signal Handling + README (PR 7/8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,75 @@ Automate GitHub Copilot license cost center assignments for your enterprise with
 
 - **PRU-Based Mode**: Simple two-tier model (PRU overages allowed/not allowed)
 - **Teams-Based Mode**: Automatic assignment based on GitHub team membership
+- **Repository-Based Mode**: Assign repos to cost centers via custom properties
+
+## Go CLI (gh extension)
+
+The recommended way to use this tool is as a GitHub CLI extension.
+
+### Installation
+
+```bash
+gh extension install renan-alm/gh-cost-center
+```
+
+### Usage
+
+```bash
+# Preview PRU-based assignments
+gh cost-center assign --mode plan
+
+# Apply PRU-based assignments (skip confirmation)
+gh cost-center assign --mode apply --yes
+
+# Teams-based mode
+gh cost-center assign --teams --mode plan
+gh cost-center assign --teams --mode apply --yes
+
+# Repository-based mode
+gh cost-center assign --repo --mode plan
+gh cost-center assign --repo --mode apply --yes
+
+# Auto-create cost centers and budgets
+gh cost-center assign --mode apply --yes --create-cost-centers --create-budgets
+
+# View configuration
+gh cost-center config
+
+# List Copilot license holders
+gh cost-center list-users
+
+# Generate summary report
+gh cost-center report
+gh cost-center report --teams
+
+# Manage cost center cache
+gh cost-center cache --stats
+gh cost-center cache --clear
+gh cost-center cache --cleanup
+
+# Show version
+gh cost-center version
+```
+
+### Cache
+
+The CLI caches cost center lookups in `.cache/cost_centers.json` to reduce API
+calls on repeated runs.  Cache entries expire after 24 hours.
+
+### Configuration
+
+Copy the example configuration and edit it:
+
+```bash
+cp config/config.example.yaml config/config.yaml
+```
+
+See `gh cost-center config` for the current resolved configuration.
+
+---
+
+## Python Version (Legacy)
 
 ## 🚀 Quick Start (5 minutes)
 

--- a/cmd/cache.go
+++ b/cmd/cache.go
@@ -2,8 +2,12 @@ package cmd
 
 import (
 	"fmt"
+	"log/slog"
+	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/renan-alm/gh-cost-center/internal/cache"
 )
 
 var (
@@ -34,18 +38,58 @@ Examples:
 			return cmd.Help()
 		}
 
-		// TODO: Wire to business logic in later PRs
+		cc, err := cache.New("", slog.Default())
+		if err != nil {
+			return fmt.Errorf("opening cache: %w", err)
+		}
+
 		if cacheStats {
-			fmt.Println("cache stats requested")
+			runCacheStats(cc)
 		}
 		if cacheClear {
-			fmt.Println("cache clear requested")
+			if err := runCacheClear(cc); err != nil {
+				return err
+			}
 		}
 		if cacheCleanup {
-			fmt.Println("cache cleanup requested")
+			if err := runCacheCleanup(cc); err != nil {
+				return err
+			}
 		}
 		return nil
 	},
+}
+
+func runCacheStats(cc *cache.Cache) {
+	stats := cc.GetStats()
+	fmt.Println()
+	fmt.Println(strings.Repeat("=", 60))
+	fmt.Println("COST CENTER CACHE STATISTICS")
+	fmt.Println(strings.Repeat("=", 60))
+	fmt.Printf("Cache file:      %s\n", stats.FilePath)
+	fmt.Printf("File size:       %d bytes\n", stats.FileSizeBytes)
+	fmt.Printf("Total entries:   %d\n", stats.TotalEntries)
+	fmt.Printf("Valid entries:   %d\n", stats.ValidEntries)
+	fmt.Printf("Expired entries: %d\n", stats.ExpiredEntries)
+	fmt.Println(strings.Repeat("=", 60))
+}
+
+func runCacheClear(cc *cache.Cache) error {
+	if err := cc.Clear(); err != nil {
+		return fmt.Errorf("clearing cache: %w", err)
+	}
+	fmt.Println("Cache cleared successfully.")
+	return nil
+}
+
+func runCacheCleanup(cc *cache.Cache) error {
+	removed, err := cc.CleanupExpired()
+	if err != nil {
+		return fmt.Errorf("cleaning up cache: %w", err)
+	}
+	stats := cc.GetStats()
+	fmt.Printf("Removed %d expired entries. %d entries remaining.\n", removed, stats.TotalEntries)
+	return nil
 }
 
 func init() {

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,0 +1,242 @@
+// Package cache provides a file-based cost center cache that reduces
+// API calls on repeated runs.  Each entry has a configurable TTL
+// (default 24 hours) and the cache is stored as JSON.
+package cache
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+const (
+	// DefaultTTLHours is the default time-to-live for cache entries.
+	DefaultTTLHours = 24
+	// DefaultCacheDir is the directory relative to the working directory.
+	DefaultCacheDir = ".cache"
+	// DefaultCacheFile is the filename inside the cache directory.
+	DefaultCacheFile = "cost_centers.json"
+	// currentVersion is the cache format version.
+	currentVersion = 1
+)
+
+// Entry represents a single cached cost center lookup.
+type Entry struct {
+	ID       string    `json:"id"`
+	Name     string    `json:"name"`
+	CachedAt time.Time `json:"cached_at"`
+	TTLHours int       `json:"ttl_hours"`
+}
+
+// IsExpired reports whether the entry has exceeded its TTL.
+func (e Entry) IsExpired() bool {
+	ttl := time.Duration(e.TTLHours) * time.Hour
+	return time.Since(e.CachedAt) > ttl
+}
+
+// cacheData is the on-disk JSON structure.
+type cacheData struct {
+	Version int              `json:"version"`
+	Entries map[string]Entry `json:"entries"`
+}
+
+// Stats holds cache statistics for display.
+type Stats struct {
+	TotalEntries   int
+	ExpiredEntries int
+	ValidEntries   int
+	FilePath       string
+	FileSizeBytes  int64
+}
+
+// Cache is a file-backed cost center cache.
+type Cache struct {
+	mu       sync.Mutex
+	filePath string
+	ttlHours int
+	data     cacheData
+	log      *slog.Logger
+}
+
+// New creates or loads a cache from the given directory.
+// If dir is empty, DefaultCacheDir is used.
+func New(dir string, logger *slog.Logger) (*Cache, error) {
+	if dir == "" {
+		dir = DefaultCacheDir
+	}
+	path := filepath.Join(dir, DefaultCacheFile)
+
+	c := &Cache{
+		filePath: path,
+		ttlHours: DefaultTTLHours,
+		log:      logger,
+		data: cacheData{
+			Version: currentVersion,
+			Entries: make(map[string]Entry),
+		},
+	}
+
+	if err := c.load(); err != nil {
+		c.log.Debug("No existing cache file, starting fresh", "path", path, "error", err)
+	}
+
+	return c, nil
+}
+
+// Get retrieves a cached entry by key.  Returns the entry and true if
+// a valid (non-expired) entry exists, or a zero Entry and false otherwise.
+func (c *Cache) Get(key string) (Entry, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	e, ok := c.data.Entries[key]
+	if !ok {
+		return Entry{}, false
+	}
+	if e.IsExpired() {
+		c.log.Debug("Cache entry expired", "key", key)
+		return Entry{}, false
+	}
+	c.log.Debug("Cache hit", "key", key, "id", e.ID)
+	return e, true
+}
+
+// Set stores or updates a cache entry and flushes to disk.
+func (c *Cache) Set(key, id, name string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.data.Entries[key] = Entry{
+		ID:       id,
+		Name:     name,
+		CachedAt: time.Now().UTC(),
+		TTLHours: c.ttlHours,
+	}
+	c.log.Debug("Cache set", "key", key, "id", id)
+	return c.save()
+}
+
+// GetStats returns statistics about the current cache.
+func (c *Cache) GetStats() Stats {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	s := Stats{
+		TotalEntries: len(c.data.Entries),
+		FilePath:     c.filePath,
+	}
+
+	for _, e := range c.data.Entries {
+		if e.IsExpired() {
+			s.ExpiredEntries++
+		} else {
+			s.ValidEntries++
+		}
+	}
+
+	if info, err := os.Stat(c.filePath); err == nil {
+		s.FileSizeBytes = info.Size()
+	}
+
+	return s
+}
+
+// Clear removes all cache entries and deletes the cache file.
+func (c *Cache) Clear() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.data.Entries = make(map[string]Entry)
+	c.log.Info("Cache cleared")
+
+	if err := os.Remove(c.filePath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing cache file: %w", err)
+	}
+	return nil
+}
+
+// CleanupExpired removes expired entries and saves to disk.
+// Returns the number of entries removed.
+func (c *Cache) CleanupExpired() (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	removed := 0
+	for key, e := range c.data.Entries {
+		if e.IsExpired() {
+			delete(c.data.Entries, key)
+			removed++
+			c.log.Debug("Removed expired entry", "key", key)
+		}
+	}
+
+	if removed > 0 {
+		if err := c.save(); err != nil {
+			return removed, err
+		}
+	}
+
+	c.log.Info("Cleanup complete", "removed", removed, "remaining", len(c.data.Entries))
+	return removed, nil
+}
+
+// FilePath returns the path to the cache file.
+func (c *Cache) FilePath() string {
+	return c.filePath
+}
+
+// load reads the cache file from disk. Returns an error if the file
+// does not exist or cannot be parsed.
+func (c *Cache) load() error {
+	f, err := os.Open(c.filePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	var d cacheData
+	if err := json.NewDecoder(f).Decode(&d); err != nil {
+		return fmt.Errorf("decoding cache file: %w", err)
+	}
+
+	if d.Version != currentVersion {
+		c.log.Warn("Cache version mismatch, starting fresh",
+			"expected", currentVersion, "found", d.Version)
+		return nil
+	}
+
+	if d.Entries == nil {
+		d.Entries = make(map[string]Entry)
+	}
+
+	c.data = d
+	c.log.Debug("Cache loaded", "entries", len(c.data.Entries), "path", c.filePath)
+	return nil
+}
+
+// save writes the cache data to disk, creating the directory if needed.
+func (c *Cache) save() error {
+	dir := filepath.Dir(c.filePath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("creating cache directory: %w", err)
+	}
+
+	f, err := os.Create(c.filePath)
+	if err != nil {
+		return fmt.Errorf("creating cache file: %w", err)
+	}
+	defer f.Close()
+
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(c.data); err != nil {
+		return fmt.Errorf("encoding cache file: %w", err)
+	}
+
+	c.log.Debug("Cache saved", "entries", len(c.data.Entries), "path", c.filePath)
+	return nil
+}

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,241 @@
+package cache
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// testLogger returns a quiet logger for tests.
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func TestNew_CreatesEmptyCache(t *testing.T) {
+	dir := t.TempDir()
+	c, err := New(dir, testLogger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c == nil {
+		t.Fatal("expected non-nil cache")
+	}
+	if len(c.data.Entries) != 0 {
+		t.Errorf("expected 0 entries, got %d", len(c.data.Entries))
+	}
+}
+
+func TestSetAndGet(t *testing.T) {
+	dir := t.TempDir()
+	c, _ := New(dir, testLogger())
+
+	if err := c.Set("my-cc", "uuid-123", "My Cost Center"); err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+
+	e, ok := c.Get("my-cc")
+	if !ok {
+		t.Fatal("expected cache hit")
+	}
+	if e.ID != "uuid-123" {
+		t.Errorf("ID: got %q, want %q", e.ID, "uuid-123")
+	}
+	if e.Name != "My Cost Center" {
+		t.Errorf("Name: got %q, want %q", e.Name, "My Cost Center")
+	}
+	if e.TTLHours != DefaultTTLHours {
+		t.Errorf("TTLHours: got %d, want %d", e.TTLHours, DefaultTTLHours)
+	}
+}
+
+func TestGet_Miss(t *testing.T) {
+	dir := t.TempDir()
+	c, _ := New(dir, testLogger())
+
+	_, ok := c.Get("nonexistent")
+	if ok {
+		t.Error("expected cache miss")
+	}
+}
+
+func TestGet_Expired(t *testing.T) {
+	dir := t.TempDir()
+	c, _ := New(dir, testLogger())
+
+	// Insert an entry that is already expired.
+	c.data.Entries["old"] = Entry{
+		ID:       "uuid-old",
+		Name:     "Old CC",
+		CachedAt: time.Now().Add(-25 * time.Hour),
+		TTLHours: DefaultTTLHours,
+	}
+
+	_, ok := c.Get("old")
+	if ok {
+		t.Error("expected cache miss for expired entry")
+	}
+}
+
+func TestClear(t *testing.T) {
+	dir := t.TempDir()
+	c, _ := New(dir, testLogger())
+
+	_ = c.Set("a", "id-a", "A")
+	_ = c.Set("b", "id-b", "B")
+
+	if err := c.Clear(); err != nil {
+		t.Fatalf("Clear failed: %v", err)
+	}
+
+	if len(c.data.Entries) != 0 {
+		t.Errorf("expected 0 entries after clear, got %d", len(c.data.Entries))
+	}
+
+	// File should be removed.
+	if _, err := os.Stat(c.filePath); !os.IsNotExist(err) {
+		t.Error("expected cache file to be removed after clear")
+	}
+}
+
+func TestCleanupExpired(t *testing.T) {
+	dir := t.TempDir()
+	c, _ := New(dir, testLogger())
+
+	// One valid, one expired.
+	_ = c.Set("valid", "id-valid", "Valid")
+	c.data.Entries["expired"] = Entry{
+		ID:       "id-expired",
+		Name:     "Expired",
+		CachedAt: time.Now().Add(-48 * time.Hour),
+		TTLHours: DefaultTTLHours,
+	}
+
+	removed, err := c.CleanupExpired()
+	if err != nil {
+		t.Fatalf("CleanupExpired failed: %v", err)
+	}
+	if removed != 1 {
+		t.Errorf("expected 1 removed, got %d", removed)
+	}
+	if len(c.data.Entries) != 1 {
+		t.Errorf("expected 1 remaining entry, got %d", len(c.data.Entries))
+	}
+	if _, ok := c.data.Entries["valid"]; !ok {
+		t.Error("expected valid entry to remain")
+	}
+}
+
+func TestCleanupExpired_NoneExpired(t *testing.T) {
+	dir := t.TempDir()
+	c, _ := New(dir, testLogger())
+
+	_ = c.Set("fresh", "id-1", "Fresh")
+
+	removed, err := c.CleanupExpired()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if removed != 0 {
+		t.Errorf("expected 0 removed, got %d", removed)
+	}
+}
+
+func TestGetStats(t *testing.T) {
+	dir := t.TempDir()
+	c, _ := New(dir, testLogger())
+
+	_ = c.Set("a", "id-a", "A")
+	c.data.Entries["b"] = Entry{
+		ID:       "id-b",
+		Name:     "B",
+		CachedAt: time.Now().Add(-48 * time.Hour),
+		TTLHours: DefaultTTLHours,
+	}
+
+	stats := c.GetStats()
+	if stats.TotalEntries != 2 {
+		t.Errorf("TotalEntries: got %d, want 2", stats.TotalEntries)
+	}
+	if stats.ValidEntries != 1 {
+		t.Errorf("ValidEntries: got %d, want 1", stats.ValidEntries)
+	}
+	if stats.ExpiredEntries != 1 {
+		t.Errorf("ExpiredEntries: got %d, want 1", stats.ExpiredEntries)
+	}
+}
+
+func TestPersistence(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write entries.
+	c1, _ := New(dir, testLogger())
+	_ = c1.Set("cc1", "id-1", "CC One")
+	_ = c1.Set("cc2", "id-2", "CC Two")
+
+	// Reload from disk.
+	c2, _ := New(dir, testLogger())
+	e, ok := c2.Get("cc1")
+	if !ok {
+		t.Fatal("expected cc1 to survive reload")
+	}
+	if e.ID != "id-1" {
+		t.Errorf("ID: got %q, want %q", e.ID, "id-1")
+	}
+
+	e2, ok := c2.Get("cc2")
+	if !ok {
+		t.Fatal("expected cc2 to survive reload")
+	}
+	if e2.Name != "CC Two" {
+		t.Errorf("Name: got %q, want %q", e2.Name, "CC Two")
+	}
+}
+
+func TestFilePath(t *testing.T) {
+	dir := t.TempDir()
+	c, _ := New(dir, testLogger())
+
+	want := filepath.Join(dir, DefaultCacheFile)
+	if c.FilePath() != want {
+		t.Errorf("FilePath: got %q, want %q", c.FilePath(), want)
+	}
+}
+
+func TestEntryIsExpired(t *testing.T) {
+	e := Entry{
+		CachedAt: time.Now().Add(-1 * time.Hour),
+		TTLHours: 2,
+	}
+	if e.IsExpired() {
+		t.Error("expected entry to still be valid (1h old, 2h TTL)")
+	}
+
+	e2 := Entry{
+		CachedAt: time.Now().Add(-3 * time.Hour),
+		TTLHours: 2,
+	}
+	if !e2.IsExpired() {
+		t.Error("expected entry to be expired (3h old, 2h TTL)")
+	}
+}
+
+func TestClear_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	c, _ := New(dir, testLogger())
+
+	// Clear without any file should not error.
+	if err := c.Clear(); err != nil {
+		t.Fatalf("Clear on empty cache should not error: %v", err)
+	}
+}
+
+func TestNew_DefaultDir(t *testing.T) {
+	// Test that passing empty string uses DefaultCacheDir.
+	// We can\'t easily test the actual default dir, but verify filepath contains it.
+	c, _ := New("", testLogger())
+	if c.filePath != filepath.Join(DefaultCacheDir, DefaultCacheFile) {
+		t.Errorf("expected default path, got %q", c.filePath)
+	}
+}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/renan-alm/gh-cost-center/internal/cache"
 	"github.com/renan-alm/gh-cost-center/internal/config"
 )
 
@@ -43,6 +44,7 @@ type Client struct {
 	baseURL    string
 	enterprise string
 	log        *slog.Logger
+	ccCache    *cache.Cache // optional cost center cache
 }
 
 // NewClient creates a Client from a loaded config.Manager.
@@ -66,6 +68,13 @@ func NewClient(cfg *config.Manager, logger *slog.Logger) (*Client, error) {
 		enterprise: cfg.Enterprise,
 		log:        logger,
 	}, nil
+}
+
+// SetCache attaches a cost center cache to the client.  When set, cost
+// center lookups check the cache before making API calls and update the
+// cache when the API responds.
+func (c *Client) SetCache(cc *cache.Cache) {
+	c.ccCache = cc
 }
 
 // APIError is returned when the GitHub API responds with a non-2xx status

--- a/main.go
+++ b/main.go
@@ -11,8 +11,32 @@
 //	gh cost-center assign --mode apply --yes
 package main
 
-import "github.com/renan-alm/gh-cost-center/cmd"
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/renan-alm/gh-cost-center/cmd"
+)
 
 func main() {
+	// SIGPIPE can occur when output is piped to head, grep, etc.
+	// Exit cleanly instead of crashing with a broken-pipe error.
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGPIPE)
+	go func() {
+		<-sig
+		os.Exit(0)
+	}()
+
+	// SIGINT (Ctrl-C) — let the Go runtime handle cleanup, but ensure
+	// we exit with a non-zero code so callers can detect interruption.
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, os.Interrupt)
+	go func() {
+		<-interrupt
+		os.Exit(130) // 128 + SIGINT(2) — standard Unix convention
+	}()
+
 	cmd.Execute()
 }


### PR DESCRIPTION
## PR 7: Cache System + Polish

Part 7 of the Python → Go conversion series.

### Cache System
- **`internal/cache/cache.go`** — File-based JSON cache with 24h TTL
  - `Get(key)`, `Set(key, id, name)`, `GetStats()`, `Clear()`, `CleanupExpired()` methods
  - Thread-safe via `sync.Mutex`
  - Stores entries at `.cache/cost_centers.json`
  - Automatic directory creation and persistence
- **`internal/cache/cache_test.go`** — 13 tests covering all cache methods (all passing with `-race`)
- **`cmd/cache.go`** — `--stats`, `--clear`, `--cleanup` subcommands fully wired

### Cache Integration
- `github.Client` gains optional `ccCache` field + `SetCache()` method
- `GetAllActiveCostCenters()` populates cache with every active cost center
- `CreateCostCenter()` checks cache before API call, updates cache on response
- `CreateCostCenterWithPreload()` checks file cache between preload-map miss and API call
- `cmd/assign.go` — `attachCache()` helper wires cache into all three assignment flows (PRU, teams, repository)

### Signal Handling
- **SIGPIPE** → graceful exit (`exit 0`) for pipe-to-head/grep usage
- **SIGINT** → clean exit with code 130 (128 + SIGINT — standard Unix convention)

### README
- Added Go CLI (`gh extension`) section with installation and usage examples
- Existing Python docs preserved under "Python Version (Legacy)" heading

### Verification
```bash
go build ./...          # ✅ clean
go vet ./...            # ✅ clean
go test -race ./...     # ✅ all pass
gh cost-center cache --stats
gh cost-center cache --clear
gh cost-center cache --cleanup
gh cost-center --help
```

### Files Changed (8)
| File | Change |
|------|--------|
| `internal/cache/cache.go` | New — cache package |
| `internal/cache/cache_test.go` | New — 13 unit tests |
| `cmd/cache.go` | Wired with real cache operations |
| `cmd/assign.go` | Added cache import + `attachCache()` helper |
| `internal/github/client.go` | Added `ccCache` field + `SetCache()` |
| `internal/github/costcenters.go` | Cache integration in CC CRUD methods |
| `main.go` | Signal handling (SIGPIPE, SIGINT) |
| `README.md` | Go CLI section + legacy Python header |
